### PR TITLE
Fix: 공통응답에러DTO 및 공통예처리객체 수정

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonErrorDTO.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonErrorDTO.java
@@ -1,8 +1,10 @@
 package com.beyond.jellyorder.common.exception;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public class CommonErrorDTO {
     private String status_message;
     private int status_code;

--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
@@ -4,13 +4,13 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.naming.AuthenticationException;
 import java.util.NoSuchElementException;
 
-@ControllerAdvice
+@RestControllerAdvice
 public class CommonExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
### ✅ 작업 개요
- 공통응답에러DTO 및 공통예처리객체 수정

### 🔧 작업 상세
- postman테스트로 예외응답값을 받지 못해 확인한 결과 CommonErrorDTO에 getter메서드가 빠져있어 Json으로 변환하지 못했음
 - CommonErrorDTO에 @Getter 추가
- 반환되는 에러 응답 객체는 JSON형식이기에 ControllerAdvice가 아닌 RestControllerAdvice로 바꿔줘야 됨.
 -  CommonExceptionHandle에 @ControllerAdivce -> @RestControllerAdivce로 변환함.

### 📌 이슈 번호
- close #14 

### ⚠️ 참고사항


### PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] PR전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.