### PR TITLE
[Feat] 공통 UUID ID 엔티티(BaseIdEntity, BaseIdAndTimeEntity) 생성 (#13)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/BaseIdAndTimeEntity.java
+++ b/src/main/java/com/beyond/jellyorder/common/BaseIdAndTimeEntity.java
@@ -1,0 +1,20 @@
+package com.beyond.jellyorder.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.UUID;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseIdAndTimeEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "id", nullable = false, updatable = false, length = 36)
+    private UUID id;
+}

--- a/src/main/java/com/beyond/jellyorder/common/BaseIdEntity.java
+++ b/src/main/java/com/beyond/jellyorder/common/BaseIdEntity.java
@@ -1,0 +1,16 @@
+package com.beyond.jellyorder.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.GenericGenerator;
+import java.util.UUID;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseIdEntity {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "id", nullable = false, updatable = false, length = 36)
+    private UUID id;
+}


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
공통 UUID ID 엔티티(BaseIdEntity, BaseIdAndTimeEntity) 생성
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- Hibernate의 uuid2 전략을 활용하여 UUID를 자동 생성하는 공통 식별자 엔티티 BaseIdEntity 생성
- BaseTimeEntity를 상속하고 UUID 자동 생성 기능을 포함한 확장 엔티티 BaseIdAndTimeEntity 추
- 추후 모든 도메인 엔티티가 해당 공통 엔티티를 상속받아 일관된 ID 생성 및 생성/수정 시간 추적 기능을 공유할 수 있도록 구조화
- UUID 타입은 CHAR(36) 문자 기반으로 설정되어 있어 MariaDB 등 문자 기반 DB에 안전하게 저장 가능
- 코드 재사용성과 유지보수성을 높이기 위한 기반 설계 단계
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #13 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- Hibernate는 기본적으로 UUID를 BINARY(16) 형태로 저장하려 하기 때문에, 명시적으로 CHAR(36) 설정을 통해 문자 기반 UUID 저장을 유도함
- BaseTimeEntity가 미리 정의되어 있어 해당 상속 계층을 유지하며 통합 구조 확장
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.