### PR TITLE
[Refactor] BaseTimeEntity에 ZONE_ID 상수 분리 및 중복 제거 (#21)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/BaseTimeEntity.java
+++ b/src/main/java/com/beyond/jellyorder/common/BaseTimeEntity.java
@@ -13,19 +13,22 @@ import java.time.ZoneId;
 @Getter
 public abstract class BaseTimeEntity {
 
-    @Column(updatable = false)
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @Column(updatable = false, nullable = false)
     protected LocalDateTime createdAt;
 
+    @Column(nullable = false)
     protected LocalDateTime updatedAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.createdAt = LocalDateTime.now(ZONE_ID);
         this.updatedAt = this.createdAt;
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.updatedAt = LocalDateTime.now(ZONE_ID);
     }
 }


### PR DESCRIPTION


### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
BaseTimeEntity의 시간 처리 및 @Column 명시 방식 개선
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- ZoneId.of("Asia/Seoul") 중복 호출을 상수 ZONE_ID로 추출하여 코드 가독성과 유지보수성 향상
- @Column에 nullable = false를 명시하여 명확한 스키마 의도 전달
- 중복된 시간 설정 로직 제거로 간결성 확보

<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #21 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 해당 변경은 DB에 직접적인 DDL 영향을 주지 않지만, nullable = false는 마이그레이션 시 주의 필요
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.