### PR TITLE
[Feat] S3 업로드 로직 개선 및 테스트 API 정비 (#23)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/s3/S3Uploader.java
+++ b/src/main/java/com/beyond/jellyorder/common/s3/S3Uploader.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import java.util.UUID;
 
 import java.io.IOException;
 
@@ -25,7 +26,7 @@ public class S3Uploader {
      */
     public String uploadMenuImage(MultipartFile menuImage, TestDTO testDTO) {
         // image명 설정
-        String fileName = "menu-" + testDTO.getName() + "-menuImage-" + menuImage.getOriginalFilename();
+        String fileName = "menu-" + testDTO.getName() + "-menuImage-" + menuImage.getOriginalFilename() + "-" + UUID.randomUUID();
 
         // 저장 객체 구성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()

--- a/src/main/java/com/beyond/jellyorder/domain/test/TestController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/test/TestController.java
@@ -16,15 +16,15 @@ public class TestController {
         this.s3Uploader = s3Uploader;
     }
 
-//    @PostMapping("/s3test")
-//    public ResponseEntity<?> s3Test(
-//            @RequestParam(value = "photo") MultipartFile photo
-//            ) {
-//        System.out.println(photo.getOriginalFilename());
-//        TestDTO testDTO = new TestDTO("이미지 파일 테스트", 10);
-//        String imageurl = s3Uploader.uploadMenuImage(photo, testDTO);
-//        return ApiResponse.ok(imageurl);
-//    }
+    @PostMapping("/s3test")
+    public ResponseEntity<?> s3Test(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("name") String name
+    ) {
+        TestDTO testDTO = new TestDTO(name, 0); // 임시 데이터
+        String imageUrl = s3Uploader.uploadMenuImage(file, testDTO);
+        return ApiResponse.ok(imageUrl);
+    }
 
     // 형진 테스트
     @GetMapping("/hyungjin")
@@ -33,7 +33,6 @@ public class TestController {
         return ApiResponse.created(testDTO, "커스텀한 메시지입니다.");
     }
 
-
     // 현지 테스트
     @GetMapping("/hyunji")
     public ResponseEntity<?> testHyunji() {
@@ -41,14 +40,12 @@ public class TestController {
         return ApiResponse.created(testDTO, "커스텀한 메시지입니다.");
     }
 
-
     // 혜성 테스트
     @GetMapping("/hyeseong")
     public ResponseEntity<?> testHyeseong() {
         TestDTO testDTO = new TestDTO("hello", 10);
         return ApiResponse.created(testDTO, "커스텀한 메시지입니다.");
     }
-
 
     // 진호 테스트
     @GetMapping("/jinho")


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
S3 업로드 파일명 중복 방지를 위한 UUID 적용 및 테스트 API 개선
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- S3 객체명 중복 방지를 위해 기존 파일명 뒤에 UUID를 추가
- uploadMenuImage()의 fileName 구성 방식 수정: 원래 파일명 + "-" + UUID
- /test/s3test API에서 MultipartFile과 이름(name)을 함께 받아 TestDTO 구성 후 업로드 가능하도록 변경
- 기존 테스트용 POST API (photo 단일 파라미터 방식) 제거
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #23 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 반환된 S3 URL을 통해 실제 이미지 접근 가능 여부를 확인해 테스트 완료
- 추후 S3 삭제 로직 구현 시, 생성된 파일명의 UUID 처리 방식과 동일한 key 추출 필요
- 테스트 결과 (정상 수행 확인):
<img width="2003" height="892" alt="s3-test-result" src="https://github.com/user-attachments/assets/06c44038-733e-4a86-9282-d81ded11f09c" />
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.