### PR TITLE
[Feat] 카테고리 추가 API 구현 (#33)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.common.exception;
 
+import com.beyond.jellyorder.domain.category.service.CategoryService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -72,5 +73,13 @@ public class CommonExceptionHandler {
         ), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(CategoryService.DuplicateCategoryNameException.class)
+    public ResponseEntity<?> handleDuplicateCategoryNameException(CategoryService.DuplicateCategoryNameException e) {
+        log.warn("중복 카테고리 예외 발생: {}", e.getMessage());
 
+        return new ResponseEntity<>(new CommonErrorDTO(
+                e.getMessage(),
+                HttpStatus.BAD_REQUEST.value()
+        ), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
@@ -1,0 +1,45 @@
+package com.beyond.jellyorder.domain.category.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.category.dto.CategoryCreateReqDto;
+import com.beyond.jellyorder.domain.category.dto.CategoryCreateResDto;
+import com.beyond.jellyorder.domain.category.service.CategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 카테고리 관련 요청을 처리하는 REST 컨트롤러 클래스.
+ * 클라이언트로부터 전달된 카테고리 생성 요청을 받아 서비스 계층에 위임하고,
+ * 결과를 표준 응답 형식으로 반환한다.
+ */
+@RestController
+@RequestMapping("/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    /**
+     * 카테고리를 생성하는 API 엔드포인트.
+     * 클라이언트로부터 전달된 JSON 요청 본문을 DTO로 변환하고, 유효성 검사를 수행한다.
+     * 이후 서비스 계층을 통해 카테고리를 저장하고, 결과를 포함한 표준 응답을 반환한다.
+     *
+     * @param reqDto 카테고리 생성 요청 데이터 (storeId(추후 삭제 예정), name, description 포함)
+     * @return 생성된 카테고리 정보와 성공 메시지를 포함한 응답
+     */
+    @PostMapping("/create")
+    public ResponseEntity<?> createCategory(
+            @RequestBody @Valid CategoryCreateReqDto reqDto
+    ) {
+        // 서비스 계층을 통해 카테고리 생성 처리
+        CategoryCreateResDto resDto = categoryService.create(reqDto);
+
+        // 표준 API 응답 포맷으로 반환 (201 Created)
+        return ApiResponse.created(resDto, reqDto.getName() + " 카테고리가 정상적으로 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
@@ -25,7 +25,7 @@ public class Category extends BaseIdAndTimeEntity {
     /**
      * 카테고리를 소속시킬 매장의 고유 식별자.
      * 현재는 테스트 및 개발 편의상 String 타입으로 지정되어 있으며,
-     * 추후 UUID 타입으로 변경 예정이다.
+     * 추후 Store 타입으로 변경 예정이다.
      */
     @Column(name = "store_id", nullable = false)
     private String storeId;

--- a/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
@@ -1,0 +1,47 @@
+package com.beyond.jellyorder.domain.category.domain;
+
+import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * 카테고리(Category) 도메인 엔티티.
+ * 매장(Store) 내에서 메뉴를 분류하는 단위이며,
+ * 이름과 설명을 포함한다.
+ *
+ * 상위 BaseIdAndTimeEntity를 상속받아 ID, 생성일, 수정일을 공통 관리한다.
+ */
+@Getter
+@Entity
+@Builder
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "category")
+public class Category extends BaseIdAndTimeEntity {
+
+    /**
+     * 카테고리를 소속시킬 매장의 고유 식별자.
+     * 현재는 테스트 및 개발 편의상 String 타입으로 지정되어 있으며,
+     * 추후 UUID 타입으로 변경 예정이다.
+     */
+    @Column(name = "store_id", nullable = false)
+    private String storeId;
+
+    /**
+     * 카테고리 이름.
+     * 예: 디저트, 음료, 샐러드 등
+     */
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    /**
+     * 카테고리에 대한 간략한 설명 또는 소개 문구.
+     */
+    @Column(length = 255, nullable = false)
+    private String description;
+
+    // 추후 명시적 Setter 또는 변경 메서드 구현 예정 (예: updateName, updateDescription 등)
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateReqDto.java
@@ -1,0 +1,43 @@
+package com.beyond.jellyorder.domain.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+/**
+ * 카테고리 생성 요청을 위한 DTO 클래스.
+ * 클라이언트가 카테고리를 생성할 때 전달해야 할 필드들을 정의하며,
+ * 유효성 검사 어노테이션을 통해 요청값의 형식을 검증한다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryCreateReqDto {
+
+    /**
+     * 카테고리를 등록할 대상 매장의 고유 식별자.
+     * 빈 문자열은 허용되지 않으며, 일반적으로 UUID 형식의 문자열이다.
+     * (2025-07-31 기준) 테스트 편의를 위해 현재는 String 타입으로 임시 지정되어 있음.
+     * 추후 로그인 및 인증 기능이 구현되면, 인증된 사용자 정보(Authentication 객체)로부터
+     * storeId(UUID)를 추출할 수 있으므로 본 필드는 제거될 예정임.
+     */
+    @NotBlank
+    private String storeId;
+
+    /**
+     * 카테고리 이름.
+     * 필수이며, 최대 20자까지 입력 가능하다.
+     */
+    @NotBlank
+    @Size(max = 20)
+    private String name;
+
+    /**
+     * 카테고리 설명 문구.
+     * 필수이며, 최대 255자까지 입력 가능하다.
+     */
+    @NotBlank
+    @Size(max = 255)
+    private String description;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateResDto.java
@@ -1,0 +1,35 @@
+package com.beyond.jellyorder.domain.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * 카테고리 생성 API의 응답 DTO.
+ * 클라이언트에게 생성된 카테고리의 정보를 반환할 때 사용된다.
+ *
+ * 필드에 final을 사용함으로써 불변 객체(immutable)로 유지되어
+ * 응답 데이터의 안정성과 무결성을 보장한다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class CategoryCreateResDto {
+
+    /**
+     * 생성된 카테고리의 고유 ID (UUID 형식)
+     */
+    private final UUID id;
+
+    /**
+     * 카테고리 이름 (예: 디저트, 음료 등)
+     */
+    private final String name;
+
+    /**
+     * 카테고리에 대한 설명 또는 소개 문구
+     */
+    private final String description;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.beyond.jellyorder.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.beyond.jellyorder.domain.category.domain.Category;
+
+import java.util.UUID;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID>, CategoryRepositoryCustom{
+    boolean existsByStoreIdAndName(String storeId, String name); // 임시 String storeId. **추후 UUID로 변경 필수**
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.category.repository;
+
+public interface CategoryRepositoryCustom {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepositoryCustomImpl.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.category.repository;
+
+public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
@@ -1,0 +1,82 @@
+package com.beyond.jellyorder.domain.category.service;
+
+import com.beyond.jellyorder.domain.category.dto.CategoryCreateReqDto;
+import com.beyond.jellyorder.domain.category.dto.CategoryCreateResDto;
+import com.beyond.jellyorder.domain.category.repository.CategoryRepository;
+import com.beyond.jellyorder.domain.category.domain.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 카테고리 관련 비즈니스 로직을 담당하는 서비스 클래스.
+ * 카테고리 생성 요청을 처리하며, 동일 storeId 내 중복된 카테고리명 존재 여부를 검증한다.
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    /**
+     * 새로운 카테고리를 생성한다.
+     * 동일 storeId 내에서 name이 중복될 경우 예외를 발생시킨다.
+     *
+     * @param categoryCreateReqDto 클라이언트로부터 전달받은 카테고리 생성 요청 DTO
+     * @return 생성된 카테고리 정보를 담은 응답 DTO
+     * @throws DuplicateCategoryNameException 동일한 이름의 카테고리가 이미 존재하는 경우 발생
+     */
+
+
+    public CategoryCreateResDto create(CategoryCreateReqDto categoryCreateReqDto) {
+        /*
+            TODO: [2025-07-31 기준] storeId에 대한 실제 매장 UUID 유효성 검증 로직 추가 예정
+            현재는 테스트 목적상 단순 UUID 문자열만 전달받고 있으나,
+            향후 Store 도메인 및 StoreRepository가 구현되면 다음과 같은 형태의 검증 로직이 삽입될 예정이다:
+
+                UUID authenticatedStoreId = getStoreIdFromAuthentication(); // 인증 객체로부터 추출
+                if (!storeRepository.existsById(authenticatedStoreId)) {
+                    throw new StoreNotFoundException(authenticatedStoreId); // 커스텀 예외 발생
+                }
+
+            이 검증은 인증된 사용자가 요청한 storeId가 실제로 존재하는 유효한 매장 식별자인지를 확인하여,
+            권한이 없는 접근이나 잘못된 데이터 요청을 사전에 차단하는 데 목적이 있다.
+
+            또한, 해당 검증은 서비스 전반에서 반복적으로 사용될 가능성이 높으므로,
+            공통 검증 유틸리티 또는 Validator 클래스를 common 패키지 하위에 별도로 구성하는 방안에 대한 논의가 필요하다.
+         */
+
+        // 중복 카테고리 이름 존재 여부 확인
+        boolean exists = categoryRepository.existsByStoreIdAndName(categoryCreateReqDto.getStoreId(), categoryCreateReqDto.getName());
+        if (exists) {
+            // 중복되면 커스텀 런타임 예외 발생 (공통 예외처리기로 위임)
+            throw new DuplicateCategoryNameException(categoryCreateReqDto.getName());
+        }
+
+        // 신규 카테고리 객체 생성 (Builder 사용)
+        Category newCategory = Category.builder()
+                .storeId(categoryCreateReqDto.getStoreId())
+                .name(categoryCreateReqDto.getName())
+                .description(categoryCreateReqDto.getDescription())
+                .build();
+
+        // DB에 저장
+        Category saved = categoryRepository.save(newCategory);
+
+        // 저장된 엔티티로 응답 DTO 구성 후 반환
+        return new CategoryCreateResDto(saved.getId(), saved.getName(), saved.getDescription());
+    }
+
+    /**
+     * 동일한 storeId 범위 내에 이미 동일한 name 값을 갖는 카테고리가 존재하는 경우 발생하는 예외이다.
+     * 서비스 계층에서 중복 카테고리 등록을 사전에 방지하기 위한 목적으로 사용된다.
+     * 현재는 CategoryService의 내부 static 클래스로 정의되어 있으나,
+     * 향후 예외 처리 일관성을 위해 공통 예외 처리 패키지로의 분리가 검토가 필요하다.
+     */
+    public static class DuplicateCategoryNameException extends RuntimeException {
+        public DuplicateCategoryNameException(String name) {
+            super("이미 존재하는 카테고리입니다: " + name);
+        }
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
@@ -27,44 +27,19 @@ public class CategoryService {
      * @return 생성된 카테고리 정보를 담은 응답 DTO
      * @throws DuplicateCategoryNameException 동일한 이름의 카테고리가 이미 존재하는 경우 발생
      */
+    public CategoryCreateResDto create(CategoryCreateReqDto dto) {
+        // TODO [2025-07-31]: storeId 유효성 검증 (인증된 점주의 storeId인지 확인)
 
-
-    public CategoryCreateResDto create(CategoryCreateReqDto categoryCreateReqDto) {
-        /*
-            TODO: [2025-07-31 기준] storeId에 대한 실제 매장 UUID 유효성 검증 로직 추가 예정
-            현재는 테스트 목적상 단순 UUID 문자열만 전달받고 있으나,
-            향후 Store 도메인 및 StoreRepository가 구현되면 다음과 같은 형태의 검증 로직이 삽입될 예정이다:
-
-                UUID authenticatedStoreId = getStoreIdFromAuthentication(); // 인증 객체로부터 추출
-                if (!storeRepository.existsById(authenticatedStoreId)) {
-                    throw new StoreNotFoundException(authenticatedStoreId); // 커스텀 예외 발생
-                }
-
-            이 검증은 인증된 사용자가 요청한 storeId가 실제로 존재하는 유효한 매장 식별자인지를 확인하여,
-            권한이 없는 접근이나 잘못된 데이터 요청을 사전에 차단하는 데 목적이 있다.
-
-            또한, 해당 검증은 서비스 전반에서 반복적으로 사용될 가능성이 높으므로,
-            공통 검증 유틸리티 또는 Validator 클래스를 common 패키지 하위에 별도로 구성하는 방안에 대한 논의가 필요하다.
-         */
-
-        // 중복 카테고리 이름 존재 여부 확인
-        boolean exists = categoryRepository.existsByStoreIdAndName(categoryCreateReqDto.getStoreId(), categoryCreateReqDto.getName());
-        if (exists) {
-            // 중복되면 커스텀 런타임 예외 발생 (공통 예외처리기로 위임)
-            throw new DuplicateCategoryNameException(categoryCreateReqDto.getName());
+        if (categoryRepository.existsByStoreIdAndName(dto.getStoreId(), dto.getName())) {
+            throw new DuplicateCategoryNameException(dto.getName());
         }
 
-        // 신규 카테고리 객체 생성 (Builder 사용)
-        Category newCategory = Category.builder()
-                .storeId(categoryCreateReqDto.getStoreId())
-                .name(categoryCreateReqDto.getName())
-                .description(categoryCreateReqDto.getDescription())
-                .build();
+        Category saved = categoryRepository.save(Category.builder()
+                .storeId(dto.getStoreId())
+                .name(dto.getName())
+                .description(dto.getDescription())
+                .build());
 
-        // DB에 저장
-        Category saved = categoryRepository.save(newCategory);
-
-        // 저장된 엔티티로 응답 DTO 구성 후 반환
         return new CategoryCreateResDto(saved.getId(), saved.getName(), saved.getDescription());
     }
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
- 본 PR은 카테고리 등록 기능 전반에 대한 구현을 포함하며, 도메인 설계부터 API 엔드포인트 구현까지 전체 계층 구조를 구성하고 연결하는 작업입니다. 클라이언트가 카테고리를 생성할 수 있도록 하기 위해 필요한 모든 구성 요소를 계층별로 구분하고 책임을 명확히 하여 구현하였습니다.
<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- 우선 도메인 계층에서는 Category 엔티티를 정의하였습니다. 이는 매장 내 메뉴를 분류하는 단위로 사용되며, storeId, name, description 필드를 포함합니다. 현재 storeId는 인증 기반 매장 관리 기능 도입 전이므로 String 타입으로 임시 설정되어 있으며, 추후 UUID 타입으로의 전환이 예정되어 있습니다. 해당 엔티티는 BaseIdAndTimeEntity를 상속받아 생성일 및 수정일을 자동으로 관리할 수 있도록 하였습니다.

- DTO 계층에서는 카테고리 생성을 위한 요청 DTO인 CategoryCreateReqDto와 응답 DTO인 CategoryCreateResDto를 정의하였습니다. 요청 DTO에는 NotBlank 및 Size와 같은 유효성 검증 어노테이션을 적용하여, 입력 값에 대한 검증을 서버 단에서 선제적으로 수행할 수 있도록 하였습니다. 응답 DTO는 UUID, name, description 필드를 포함하며, 모든 필드를 final로 선언하여 불변 객체로 설계하였습니다. 이를 통해 응답 데이터의 무결성과 안정성을 확보하였습니다.

- Repository 계층에서는 JpaRepository를 상속하는 CategoryRepository를 정의하였으며, existsByStoreIdAndName() 메서드를 추가하여 중복된 카테고리명 검증이 가능하도록 하였습니다. 또한, 확장 가능한 구조를 위해 CategoryRepositoryCustom 인터페이스와 그 구현체인 CategoryRepositoryCustomImpl을 구성하였습니다. 현재는 구현 내용이 없으나, 향후 QueryDSL 기반의 동적 쿼리 또는 복잡한 조회 조건을 처리할 수 있도록 설계적 기반을 마련해두었습니다.

- 서비스 계층에서는 CategoryService 내 create() 메서드를 통해 실제 비즈니스 로직을 구현하였습니다. 먼저, 동일한 storeId 내에 동일한 이름의 카테고리가 존재하는 경우, DuplicateCategoryNameException이라는 내부 정의된 예외를 발생시켜 중복 등록을 방지하였습니다. 해당 예외는 공통 예외 처리기에서 처리되며, 클라이언트에게 400 Bad Request 상태 코드와 함께 명확한 메시지를 전달합니다. 중복이 아닐 경우, 요청 정보를 바탕으로 카테고리 엔티티를 생성하고 저장한 후, 응답 DTO로 변환하여 반환합니다.

- API 계층에서는 /category/create POST 엔드포인트를 구현하였습니다. 클라이언트로부터 전달받은 요청은 @RequestBody와 @Valid를 통해 DTO로 변환 및 유효성 검증을 수행하며, 이후 서비스의 create() 메서드를 호출하여 생성 로직을 처리합니다. 결과는 공통 응답 객체인 ApiResponse.created()를 통해 일관된 응답 포맷으로 반환되며, 201 Created 상태 코드와 함께 성공 메시지를 포함합니다.

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #33 
<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 현재 storeId는 클라이언트가 직접 전달하는 방식이며, UUID 형식의 문자열로 전제하고 있습니다. 다만, 형식 검증은 아직 적용되지 않았으며, 추후 인증 기반 구조가 도입되면 인증 객체에서 storeId를 추출하고 해당 필드는 DTO에서 제거될 예정입니다. 또한, 커스텀 레포지토리 구현은 현재 내용이 없지만, 구조적 준비를 마친 상태이며, 향후 QueryDSL이나 동적 조건 쿼리 구현 시 재사용될 수 있도록 설계하였습니다.

### 테스트 결과:
- 임의의 UUID를 입력하여 요청을 수행한 결과, 카테고리 정보가 정상적으로 데이터베이스에 저장됨을 확인하였습니다.
<img width="382" height="340" alt="image" src="https://github.com/user-attachments/assets/5b57faa3-b8d0-4fdc-9d48-87bb1ad06377" />
<img width="556" height="42" alt="image" src="https://github.com/user-attachments/assets/76faf0f1-a86e-43a0-af1b-c79fedc0d86d" /> <br/>


<br/>


- 동일한 UUID와 카테고리명을 입력하여 POST 요청을 다시 보낸 결과, 중복 처리 로직이 정상적으로 작동함을 확인하였습니다.
<img width="385" height="289" alt="image" src="https://github.com/user-attachments/assets/22e89e84-cff7-4b28-98f2-ce7b0f8e0b19" />

<br/>


- UUID만 변경한 상태로 동일한 카테고리명을 입력하여 POST 요청을 수행한 결과, 카테고리 정보가 정상적으로 데이터베이스에 저장됨을 확인하였습니다.
<img width="383" height="345" alt="image" src="https://github.com/user-attachments/assets/c7252111-0512-4ffd-b18a-a278ecb096f5" />
<img width="556" height="53" alt="image" src="https://github.com/user-attachments/assets/54a0d50e-0cba-425f-82ba-98fc4baeee8b" /> <br/>


<br/>



## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.