### PR TITLE
[Feat] 식자재 추가 API 구현 (#35)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.common.exception;
 
+import com.beyond.jellyorder.domain.ingredient.service.IngredientService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -72,5 +73,13 @@ public class CommonExceptionHandler {
         ), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(IngredientService.DuplicateIngredientNameException.class)
+    public ResponseEntity<?> handleDuplicateIngredientNameException(IngredientService.DuplicateIngredientNameException e) {
+        log.warn("중복 식자재 예외 발생: {}", e.getMessage());
 
+        return new ResponseEntity<>(new CommonErrorDTO(
+                e.getMessage(),
+                HttpStatus.BAD_REQUEST.value()
+        ), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
@@ -1,0 +1,32 @@
+package com.beyond.jellyorder.domain.ingredient.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateReqDto;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateResDto;
+import com.beyond.jellyorder.domain.ingredient.service.IngredientService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 식자재 관련 요청을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/ingredient")
+@RequiredArgsConstructor
+public class IngredientController {
+
+    private final IngredientService ingredientService;
+
+    /**
+     * 새로운 식자재 등록
+     */
+    @PostMapping("/create")
+    public ResponseEntity<?> createIngredient(
+            @RequestBody @Valid IngredientCreateReqDto reqDto) {
+
+        IngredientCreateResDto resDto = ingredientService.create(reqDto);
+        return ApiResponse.created(resDto, resDto.getName() + " 식자재가 정상적으로 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
@@ -1,0 +1,51 @@
+package com.beyond.jellyorder.domain.ingredient.domain;
+
+import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 재료(Ingredient) 엔티티.
+ * 매장에서 사용하는 식자재(예: 치즈, 소스 등)를 정의한다.
+ * 기본적으로 이름(name)과 재고 상태(status)를 포함하며,
+ * BaseIdAndTimeEntity를 상속받아 UUID 기반의 식별자와 생성/수정 시각을 함께 관리한다.
+ */
+@Getter
+@Entity
+@Builder
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "ingredient")
+public class Ingredient extends BaseIdAndTimeEntity {
+
+    /**
+     * 카테고리를 소속시킬 매장의 고유 식별자.
+     * 현재는 테스트 및 개발 편의상 String 타입으로 지정되어 있으며,
+     * 추후 UUID 타입으로 변경 예정이다.
+     */
+    @Column(name = "store_id", nullable = false)
+    private String storeId;
+
+    /**
+     * 식자재명.
+     * - 최대 20자까지 입력 가능
+     * - null 불가
+     * - 예: '체다 치즈', '양상추', '바베큐 소스'
+     */
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    /**
+     * 재고 상태.
+     * - Enum 클래스 IngredientStatus에 정의된 값 사용
+     * - EnumType.STRING으로 저장하여 데이터베이스에 문자열 형태로 보관 (가독성 및 안정성 향상)
+     * - 기본값은 SUFFICIENT (충분) 상태
+     */
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private IngredientStatus status = IngredientStatus.SUFFICIENT;
+
+    // 추후: 재고 상태 변경 메서드 등 도메인 로직 추가 가능 (e.g., updateStatus(IngredientStatus.INSUFFICIENT))
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
@@ -16,13 +16,18 @@ import lombok.*;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "ingredient")
+@Table(name = "category", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_category_storeId_name",
+                columnNames = {"store_id", "name"}
+        )
+})
 public class Ingredient extends BaseIdAndTimeEntity {
 
     /**
      * 카테고리를 소속시킬 매장의 고유 식별자.
      * 현재는 테스트 및 개발 편의상 String 타입으로 지정되어 있으며,
-     * 추후 UUID 타입으로 변경 예정이다.
+     * 추후 Store 타입으로 변경 예정이다.
      */
     @Column(name = "store_id", nullable = false)
     private String storeId;

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/IngredientStatus.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/IngredientStatus.java
@@ -1,0 +1,7 @@
+package com.beyond.jellyorder.domain.ingredient.domain;
+
+public enum IngredientStatus {
+    INSUFFICIENT, // 부족
+    SUFFICIENT,   // 충분
+    EXHAUSTED     // 소진
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientCreateReqDto.java
@@ -1,0 +1,41 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import com.beyond.jellyorder.domain.ingredient.domain.IngredientStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 식자재 생성 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class IngredientCreateReqDto {
+
+    /**
+     * 재료를 등록할 대상 매장의 고유 식별자.
+     * 빈 문자열은 허용되지 않으며, 일반적으로 UUID 형식의 문자열이다.
+     * (2025-07-31 기준) 테스트 편의를 위해 현재는 String 타입으로 임시 지정되어 있음.
+     * 추후 로그인 및 인증 기능이 구현되면, 인증된 사용자 정보(Authentication 객체)로부터
+     * storeId(UUID)를 추출할 수 있으므로 본 필드는 제거될 예정임.
+     */
+    @NotBlank
+    private String storeId;
+
+    /**
+     * 식자재명 (예: 양상추, 체다치즈)
+     */
+    @NotBlank(message = "식자재명은 필수입니다.")
+    @Size(max = 20, message = "식자재명은 20자 이하로 입력해야 합니다.")
+    private String name;
+
+    /**
+     * 재고 상태 (예: SUFFICIENT, INSUFFICIENT, EXHAUSTED)
+     */
+    @NotNull(message = "상태는 필수 선택입니다.")
+    private IngredientStatus status;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientCreateResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientCreateResDto.java
@@ -1,0 +1,18 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import com.beyond.jellyorder.domain.ingredient.domain.IngredientStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * 식자재 생성 응답 DTO
+ */
+@Getter
+@Builder
+public class IngredientCreateResDto {
+    private UUID id;
+    private String name;
+    private IngredientStatus status;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
@@ -1,0 +1,19 @@
+package com.beyond.jellyorder.domain.ingredient.repository;
+
+import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface IngredientRepository extends JpaRepository<Ingredient, UUID>, IngredientRepositoryCustom{
+    /**
+     * 주어진 storeId와 재료명(name)에 해당하는 재료가 이미 존재하는지 여부를 확인한다.
+     *
+     * @param storeId 매장 ID (현재는 String이지만, 추후 UUID로 변경 예정)
+     * @param name    재료명
+     * @return 존재 여부
+     */
+    boolean existsByStoreIdAndName(String storeId, String name);  // TODO: UUID로 교체
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepositoryCustom.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.ingredient.repository;
+
+public interface IngredientRepositoryCustom {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepositoryCustomImpl.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepositoryCustomImpl.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.ingredient.repository;
+
+public class IngredientRepositoryCustomImpl implements IngredientRepositoryCustom{
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
@@ -1,0 +1,88 @@
+package com.beyond.jellyorder.domain.ingredient.service;
+
+import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateReqDto;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateResDto;
+import com.beyond.jellyorder.domain.ingredient.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 식자재(Ingredient) 관련 비즈니스 로직을 담당하는 서비스 클래스.
+ * - 식자재 생성
+ * - 중복 이름 검사
+ * - 매장별 식자재 관리 등
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class IngredientService {
+
+    private final IngredientRepository ingredientRepository;
+
+    /**
+     * 새로운 식자재를 생성한다.
+     * - 동일 매장(storeId) 내에서 이름(name)이 중복되면 예외를 발생시킨다.
+     * - 생성된 식자재를 저장 후 응답 DTO로 변환하여 반환한다.
+     *
+     * @param reqDto 클라이언트로부터 전달받은 식자재 생성 요청 DTO
+     * @return 생성된 식자재 정보를 담은 응답 DTO
+     * @throws DuplicateIngredientNameException 동일 매장 내에 이름이 중복되는 경우
+     */
+    public IngredientCreateResDto create(IngredientCreateReqDto reqDto) {
+        /*
+            TODO: [2025-07-31 기준] storeId에 대한 실제 매장 UUID 유효성 검증 로직 추가 예정
+            현재는 테스트 목적상 단순 UUID 문자열만 전달받고 있으나,
+            향후 Store 도메인 및 StoreRepository가 구현되면 다음과 같은 형태의 검증 로직이 삽입될 예정이다:
+
+                UUID authenticatedStoreId = getStoreIdFromAuthentication(); // 인증 객체로부터 추출
+                if (!storeRepository.existsById(authenticatedStoreId)) {
+                    throw new StoreNotFoundException(authenticatedStoreId); // 커스텀 예외 발생
+                }
+
+            이 검증은 인증된 사용자가 요청한 storeId가 실제로 존재하는 유효한 매장 식별자인지를 확인하여,
+            권한이 없는 접근이나 잘못된 데이터 요청을 사전에 차단하는 데 목적이 있다.
+
+            또한, 해당 검증은 서비스 전반에서 반복적으로 사용될 가능성이 높으므로,
+            공통 검증 유틸리티 또는 Validator 클래스를 common 패키지 하위에 별도로 구성하는 방안에 대한 논의가 필요하다.
+         */
+
+        // 동일 매장 내에 동일한 이름의 식자재가 존재하는지 확인
+        boolean exists = ingredientRepository.existsByStoreIdAndName(reqDto.getStoreId(), reqDto.getName());
+        if (exists) {
+            // 중복 식자재 존재 시 예외 발생
+            throw new DuplicateIngredientNameException(reqDto.getName());
+        }
+
+        // 식자재 엔티티 생성
+        Ingredient ingredient = Ingredient.builder()
+                .storeId(reqDto.getStoreId())
+                .name(reqDto.getName())
+                .status(reqDto.getStatus())
+                .build();
+
+        // DB에 저장
+        Ingredient saved = ingredientRepository.save(ingredient);
+
+        // 저장된 식자재 정보를 응답 DTO로 변환하여 반환
+        return IngredientCreateResDto.builder()
+                .id(saved.getId())
+                .name(saved.getName())
+                .status(saved.getStatus())
+                .build();
+    }
+
+    /**
+     * 동일한 이름의 식자재가 이미 존재하는 경우 발생하는 예외 클래스.
+     * - 매장 단위 중복 등록 방지 목적
+     * - 전역 예외 처리 핸들러에서 처리 가능
+     */
+    public static class DuplicateIngredientNameException extends RuntimeException {
+        public DuplicateIngredientNameException(String name) {
+            super("이미 존재하는 식자재입니다: " + name);
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
- 식자재(Ingredient) 등록 기능 전체 구현 – 엔티티, DTO, Repository, Service, Controller, 예외 처리 포함
<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- Ingredient 엔티티 및 IngredientStatus Enum 정의: 매장에서 사용하는 식자재를 관리하기 위한 Ingredient 엔티티를 정의하였으며, 식자재의 재고 상태는 IngredientStatus Enum으로 관리한다. 기본 컬럼은 storeId, name, status이며, BaseIdAndTimeEntity를 상속받아 UUID 기반 식별자와 생성/수정 시간을 자동 관리하도록 구성하였다.
- 식자재 생성 요청 및 응답 DTO 정의: 클라이언트로부터 전달받는 요청은 IngredientCreateReqDto로, 응답은 IngredientCreateResDto로 분리하여 명확하게 설계하였다. 유효성 검증을 위해 @NotBlank, @NotNull, @Size 등의 애너테이션을 활용하였으며, 상태 값은 Enum 기반으로 제한하였다.
- Repository 인터페이스 및 중복 검사 기능 구현: IngredientRepository는 JpaRepository를 상속하여 기본 CRUD 기능을 제공하며, 추가로 existsByStoreIdAndName() 메서드를 통해 동일 매장 내 중복 이름 여부를 확인할 수 있도록 하였다. 확장 가능성을 고려하여 Custom Repository 인터페이스도 구성하였다.
- Service 레이어에서 비즈니스 로직 구현: IngredientService에서는 중복 이름 검사, 엔티티 생성 및 저장, 응답 DTO 반환까지의 전체 로직을 처리한다. 중복된 이름일 경우 DuplicateIngredientNameException을 발생시키며, 추후 인증 기반 storeId 검증 로직 도입을 염두에 두고 구조를 설계하였다.
- Controller 구현 및 등록 API 개발: /ingredient/create POST 요청으로 식자재를 등록할 수 있는 엔드포인트를 구현하였다. 입력은 JSON 형태로 전달되며, @Valid와 @RequestBody를 통해 DTO 유효성 검증을 수행한다. 성공 시 일관된 구조의 ApiResponse(created)를 반환한다.
- 예외 핸들러 구현 및 예외 메시지 표준화: 전역 예외 처리 클래스(CommonExceptionHandler)에 DuplicateIngredientNameException 처리 메서드를 추가하였다. 중복 예외 발생 시 HTTP 400 상태코드와 함께 명확한 메시지를 반환하며, 로그는 warn 수준으로 기록된다. 이를 통해 클라이언트와 서버 간 명확한 피드백 구조를 완성하였다.

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #35 
<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 현재 storeId는 임시로 String 형태로 받아 사용하고 있으며, 추후 인증/인가 시스템이 적용되면 인증된 사용자로부터 UUID를 추출하는 방식으로 전환될 예정임
- IngredientRepositoryCustom은 확장을 고려해 구조만 생성해둔 상태이며, 향후 조건부 검색 등 커스텀 기능이 요구될 때 구체화 예정임
- 추후 재고 변경, 삭제, 목록 조회 등 연계 기능 추가 시 현재 구조를 그대로 활용 가능하도록 레이어 간 의존성을 최소화하여 설계함
- store_id를 식자재(Ingredient) 테이블에 추가한 이유는 매장 단위의 재고 관리를 명확히 분리하고 독립적인 식자재 관리 체계를 구축하기 위함입니다. 기존에는 식자재가 메뉴(menu)와의 관계를 통해 간접적으로 매장(store)과 연결되는 구조였지만, 이는 "식자재가 반드시 메뉴에 포함되어야만 매장과 연관된다"는 비직관적인 제약을 야기할 수 있었습니다. 실무 환경에서는 메뉴에 속하지 않은 식자재라도 미리 등록하여 재고 상태를 관리하거나, 향후 사용을 위해 준비되는 경우가 많습니다. 이러한 상황에서 menu_ingredient 관계만으로는 소속 매장을 식별할 수 없기 때문에, storeId를 식자재 엔티티에 명시적으로 포함시켜야 안정적인 매장 기반 필터링, 중복 검증, 재고 상태 추적 등이 가능해집니다. 결과적으로 이는 도메인 독립성과 기능 확장성, 데이터 정합성을 높이는 방향으로 설계를 개선한 조치입니다.
<img width="1266" height="780" alt="image" src="https://github.com/user-attachments/assets/88238594-15e7-45dc-87ff-f78062710c29" />


### 테스트 결과:
- 임의의 UUID를 입력하여 요청을 수행한 결과, 식자재 정보가 정상적으로 데이터베이스에 저장됨을 확인하였습니다.
<img width="753" height="741" alt="image" src="https://github.com/user-attachments/assets/b38ef0ee-95ce-473b-bb73-dbf95ce86083" />
<img width="913" height="80" alt="image" src="https://github.com/user-attachments/assets/9e88bb8e-50d2-4838-b7ef-7481d6e5e2d4" />

- 동일한 UUID와 식자재명을 입력하여 POST 요청을 다시 보낸 결과, 중복 처리 로직이 정상적으로 작동함을 확인하였습니다.
<img width="759" height="576" alt="image" src="https://github.com/user-attachments/assets/1ad722f7-7ffe-4d17-b763-ecf8774a4ed7" />

- UUID만 변경한 상태로 동일한 식자재명을 입력하여 POST 요청을 수행한 결과, 카테고리 정보가 정상적으로 데이터베이스에 저장됨을 확인하였습니다.
<img width="760" height="736" alt="image" src="https://github.com/user-attachments/assets/16e07b81-9b61-402e-8c23-af96f77607c6" />

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.