### PR TITLE
[Feat] CustomException 추가 및 StoreTable, Zone 도메인 서비스에 도입

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/apiResponse/ApiResponse.java
+++ b/src/main/java/com/beyond/jellyorder/common/apiResponse/ApiResponse.java
@@ -59,6 +59,3 @@ public class ApiResponse {
 
 
 
-
-
-

--- a/src/main/java/com/beyond/jellyorder/common/apiResponse/CommonDTO.java
+++ b/src/main/java/com/beyond/jellyorder/common/apiResponse/CommonDTO.java
@@ -9,6 +9,6 @@ import org.springframework.http.ResponseEntity;
 @Getter
 public class CommonDTO {
     private String status_message;
-    private int status_code;
+    private Integer status_code;
     private Object result;
 }

--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonErrorDTO.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonErrorDTO.java
@@ -1,11 +1,16 @@
 package com.beyond.jellyorder.common.exception;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Builder
 public class CommonErrorDTO {
     private String status_message;
-    private int status_code;
+    private Integer status_code;
+    private Object result;
 }

--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
@@ -18,58 +18,73 @@ public class CommonExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<?> illegalException(IllegalArgumentException e) {
-        log.error(e.getMessage());
-        return new ResponseEntity<>(new CommonErrorDTO(
-                e.getMessage(),
-                HttpStatus.BAD_REQUEST.value()
-        ), HttpStatus.BAD_REQUEST);
+        log.error("[IllegalArgumentException] code = {}, message = {}", HttpStatus.BAD_REQUEST, e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.BAD_REQUEST.value())
+                        .build()
+
+                );
     }
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<?> entityException(EntityNotFoundException e) {
-        log.error(e.getMessage());
-        return new ResponseEntity<>(new CommonErrorDTO(
-                e.getMessage(),
-                HttpStatus.NOT_FOUND.value()
-        ), HttpStatus.NOT_FOUND);
+        log.error("[EntityNotFoundException] code = {}, message = {}", HttpStatus.NOT_FOUND, e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.NOT_FOUND.value())
+                        .build()
+                );
     }
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<?> NoSuchElementException(NoSuchElementException e) {
-        log.error(e.getMessage());
-        return new ResponseEntity<>(new CommonErrorDTO(
-                e.getMessage(),
-                HttpStatus.NOT_FOUND.value()
-        ), HttpStatus.NOT_FOUND);
+        log.error("[NoSuchElementException] code = {}, message = {}", HttpStatus.NOT_FOUND, e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.NOT_FOUND.value())
+                        .build()
+                );
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> MethodNotValidException(MethodArgumentNotValidException e) {
-        log.error(e.getMessage());
+        log.error("[MethodArgumentNotValidException] code = {}, message = {}", HttpStatus.BAD_REQUEST, e.getMessage());
         String defaultMessage = e.getBindingResult().getFieldError().getDefaultMessage();
 
-        return new ResponseEntity<>(new CommonErrorDTO(
-                defaultMessage,
-                HttpStatus.BAD_REQUEST.value()
-        ), HttpStatus.BAD_REQUEST);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonErrorDTO.builder()
+                        .status_message(defaultMessage)
+                        .status_code(HttpStatus.BAD_REQUEST.value())
+                        .build()
+                );
+
     }
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<?> authenticationException(AuthenticationException e) {
-        log.error(e.getMessage());
-        return new ResponseEntity<>(new CommonErrorDTO(
-                e.getMessage(),
-                HttpStatus.FORBIDDEN.value()
-        ), HttpStatus.FORBIDDEN);
+        log.error("[AuthenticationException] code = {}, message = {}", HttpStatus.FORBIDDEN, e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.FORBIDDEN.value())
+                        .build()
+                );
     }
 
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<?> DataViolationException(DataIntegrityViolationException e) {
-        log.error(e.getMessage());
-        return new ResponseEntity<>(new CommonErrorDTO(
-                e.getMessage(),
-                HttpStatus.BAD_REQUEST.value()
-        ), HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<?> duplicateResourceException(DuplicateResourceException e) {
+        log.error("[DuplicateResourceException] code = {}, message = {}", HttpStatus.BAD_REQUEST, e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.BAD_REQUEST.value())
+                        .result(e.getData())
+                        .build()
+                );
     }
 
 

--- a/src/main/java/com/beyond/jellyorder/common/exception/DuplicateResourceException.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/DuplicateResourceException.java
@@ -1,0 +1,20 @@
+package com.beyond.jellyorder.common.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateResourceException extends RuntimeException{
+
+    private final Object data;
+
+    public DuplicateResourceException(String errorMessage) {
+        super(errorMessage);
+        this.data = null;
+    }
+
+    public DuplicateResourceException(String errorMessage, Object data) {
+        super(errorMessage);
+        this.data = data;
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.domain.storetable.service;
 
+import com.beyond.jellyorder.common.exception.DuplicateResourceException;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
 import com.beyond.jellyorder.domain.storetable.dto.StoreTableCreateReqDTO;
@@ -47,7 +48,7 @@ public class StoreTableService {
         List<String> existingNames = storeTableRepository.findNamesByStoreAndNames(store, requestNames);
 
         if (!existingNames.isEmpty()) {
-            throw new IllegalArgumentException("이미 존재하는 테이블 이름입니다: " + existingNames);
+            throw new DuplicateResourceException("이미 존재하는 테이블 이름입니다: ",existingNames);
         }
 
         // 중복 없으면 저장

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/service/ZoneService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/service/ZoneService.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.domain.storetable.service;
 
+import com.beyond.jellyorder.common.exception.DuplicateResourceException;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
 import com.beyond.jellyorder.domain.storetable.dto.ZoneCreateReqDTO;
@@ -36,7 +37,7 @@ public class ZoneService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 매장이 존재하지 않습니다."));
 
         if (zoneRepository.existsByStoreAndName(store, dto.getZoneName())) {
-            throw new IllegalArgumentException("해당 매장에 동일한 구역 이름이 존재합니다.");
+            throw new DuplicateResourceException("해당 매장에 동일한 구역 이름이 존재합니다.");
         }
 
         Zone zone = dto.toEntity(store);
@@ -74,7 +75,7 @@ public class ZoneService {
         }
 
         if (zoneRepository.existsByStoreAndName(store, dto.getZoneName())) {
-            throw new IllegalArgumentException("해당 매장에 동일한 구역 이름이 존재합니다.");
+            throw new DuplicateResourceException("해당 매장에 동일한 구역 이름이 존재합니다.");
         }
 
         zone.updateName(dto.getZoneName());

--- a/src/main/java/com/beyond/jellyorder/domain/test/testexception/BusinessException.java
+++ b/src/main/java/com/beyond/jellyorder/domain/test/testexception/BusinessException.java
@@ -1,0 +1,23 @@
+package com.beyond.jellyorder.domain.test.testexception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+    private final Object data;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.data = null;
+    }
+
+    public BusinessException(ErrorCode errorCode, Object data) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/test/testexception/ErrorCode.java
+++ b/src/main/java/com/beyond/jellyorder/domain/test/testexception/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.beyond.jellyorder.domain.test.testexception;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Store
+
+    // Menu
+
+    // Category
+
+    // Ingredient
+
+    // StoreTable
+    DUPLICATE_STORE_TABLE_NAME("이미 존재하는 테이블 이름입니다.", HttpStatus.BAD_REQUEST),
+    STORE_TABLE_NOT_FOUND("해당 테이블이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    // Zone
+    DUPLICATE_ZONE_NAME("해당 테이블이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ZONE_NOT_FOUND("해당 구역이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    // system_error
+    INTERNAL_SERVER_ERROR("예상하지 못한 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_INPUT("잘못된 입력입니다.", HttpStatus.BAD_REQUEST);
+
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/test/testexception/GlobalExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/domain/test/testexception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.beyond.jellyorder.domain.test.testexception;
+
+import com.beyond.jellyorder.common.exception.CommonErrorDTO;
+import com.beyond.jellyorder.domain.test.testexception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    // 기본적인 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<CommonErrorDTO> handleCustomException(BusinessException e) {
+        log.error("[BusinessException] code={}, message={}", e.getErrorCode(), e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(e.getErrorCode().getStatus().value())
+                        .result(e.getData())
+                        .build());
+    }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
### 📋 작업 개요
 CustomException 추가 및 StoreTable, Zone 도메인 서비스에 도입
<br/>
### 🔧 작업 상세
- DuplicateResourceException 커스텀 예외를 추가하여 DB에 중복 값 예외 처리에 대해 구체성을 높임

-  DuplicateResourceException
```
@Getter
public class DuplicateResourceException extends RuntimeException{

    private final Object data;

    public DuplicateResourceException(String errorMessage) {
        super(errorMessage);
        this.data = null;
    }

    public DuplicateResourceException(String errorMessage, Object data) {
        super(errorMessage);
        this.data = data;
    }
}
```

- StoreTableService
```
 if (!existingNames.isEmpty()) {
            throw new DuplicateResourceException("이미 존재하는 테이블 이름입니다: ",existingNames);
        }
```


- ZoneService
```
if (zoneRepository.existsByStoreAndName(store, dto.getZoneName())) {
            throw new DuplicateResourceException("해당 매장에 동일한 구역 이름이 존재합니다.");
        }
```


- 에러 메시지만 보낼 수 있는 기존 예외에서, 문제가 된 데이터를 Object타입의 데이터 값으로 반환 가능 설계


### 🔧 도입 후 테스트

<img width="834" height="562" alt="스크린샷 2025-07-31 오후 2 00 18" src="https://github.com/user-attachments/assets/55a9bf41-23b7-4a38-9f80-228344aebc47" />
<br/>

### 📌 이슈 번호
close #31 
<br/>

### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 추후 논의를 통해  Test패키지 속 확장 CustomException를 정의

<br/>

### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.