### PR TITLE
[Feat] 전체 테이블 리스트 조회 api 구현 (#31)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.domain.store.entity;
 
+import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,13 +18,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Store {
-
-    @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
-    private UUID id;
+public class Store extends BaseIdAndTimeEntity {
 
     @Column(unique = true, nullable = false, columnDefinition = "VARCHAR(50)")
     private String loginId;

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/controller/StoreTableController.java
@@ -2,6 +2,7 @@ package com.beyond.jellyorder.domain.storetable.controller;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.storetable.dto.StoreTableCreateReqDTO;
+import com.beyond.jellyorder.domain.storetable.dto.StoreTableListResDTO;
 import com.beyond.jellyorder.domain.storetable.dto.StoreTableResDTO;
 import com.beyond.jellyorder.domain.storetable.service.StoreTableService;
 import jakarta.validation.Valid;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/store-table")
 @RequiredArgsConstructor
+//    @PreAuthorize("hasRole('STORE')") 토큰 발급 시 추가 예정
 public class StoreTableController {
 
     private final StoreTableService storeTableService;
@@ -27,6 +29,14 @@ public class StoreTableController {
         reqDTO.validate();
         List<StoreTableResDTO> resDTO = storeTableService.createTables(reqDTO, storeLoginId);
         return ApiResponse.created(resDTO, "테이블이 생성되었습니다.");
+    }
+
+    @GetMapping("/list/{storeLoginId}")
+    public ResponseEntity<?> getStoreTableList(
+            @PathVariable String storeLoginId
+    ) {
+        List<StoreTableListResDTO> resDTOs = storeTableService.getStoreTableList(storeLoginId);
+        return ApiResponse.ok(resDTOs);
     }
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/StoreTableDetail.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/StoreTableDetail.java
@@ -1,0 +1,24 @@
+package com.beyond.jellyorder.domain.storetable.dto;
+
+import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+// StoreTableListResDTO 속 테이블 dto
+@Getter
+@Builder
+public class StoreTableDetail {
+    private UUID storeTableId;
+    private String storeTableName;
+    private Integer seatCount;
+
+    public static StoreTableDetail from(StoreTable storeTable) {
+        return StoreTableDetail.builder()
+                .storeTableId(storeTable.getId())
+                .storeTableName(storeTable.getName())
+                .seatCount(storeTable.getSeatCount())
+                .build();
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/StoreTableListResDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/StoreTableListResDTO.java
@@ -1,0 +1,27 @@
+package com.beyond.jellyorder.domain.storetable.dto;
+
+import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
+import com.beyond.jellyorder.domain.storetable.entity.Zone;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class StoreTableListResDTO {
+    private UUID zoneId;
+    private String zoneName;
+    List<StoreTableDetail> storeTableDetailList;
+
+    public static StoreTableListResDTO from(Zone zone, List<StoreTableDetail> storeTableDetailList) {
+               return StoreTableListResDTO.builder()
+                       .zoneId(zone.getId())
+                       .zoneName(zone.getName())
+                       .storeTableDetailList(storeTableDetailList)
+                       .build();
+    }
+
+}
+

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/entity/StoreTable.java
@@ -40,8 +40,4 @@ public class StoreTable extends BaseIdAndTimeEntity {
     @Builder.Default
     @Column(name = "seat_count", nullable = false)
     private Integer seatCount = 4;
-
-
-
-
 }

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/repository/StoreTableRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/repository/StoreTableRepository.java
@@ -2,6 +2,7 @@ package com.beyond.jellyorder.domain.storetable.repository;
 
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
+import com.beyond.jellyorder.domain.storetable.entity.Zone;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,5 +14,16 @@ public interface StoreTableRepository extends JpaRepository<StoreTable, UUID> {
 
     @Query("SELECT st.name FROM StoreTable st WHERE st.store = :store AND st.name IN :names")
     List<String> findNamesByStoreAndNames(@Param("store") Store store, @Param("names") List<String> names);
+
+    List<StoreTable> findAllByZone(Zone zone);
+
+    @Query("""
+    SELECT st FROM StoreTable st
+    JOIN FETCH st.zone z
+    JOIN FETCH st.store s
+    WHERE s.loginId = :storeLoginId
+""")
+    List<StoreTable> findAllByStoreLoginIdWithZoneAndStore(@Param("storeLoginId") String storeLoginId);
+
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
@@ -3,9 +3,7 @@ package com.beyond.jellyorder.domain.storetable.service;
 import com.beyond.jellyorder.common.exception.DuplicateResourceException;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
-import com.beyond.jellyorder.domain.storetable.dto.StoreTableCreateReqDTO;
-import com.beyond.jellyorder.domain.storetable.dto.StoreTableNameReqDTO;
-import com.beyond.jellyorder.domain.storetable.dto.StoreTableResDTO;
+import com.beyond.jellyorder.domain.storetable.dto.*;
 import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
 import com.beyond.jellyorder.domain.storetable.entity.Zone;
 import com.beyond.jellyorder.domain.storetable.repository.StoreTableRepository;
@@ -15,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -48,7 +48,7 @@ public class StoreTableService {
         List<String> existingNames = storeTableRepository.findNamesByStoreAndNames(store, requestNames);
 
         if (!existingNames.isEmpty()) {
-            throw new DuplicateResourceException("이미 존재하는 테이블 이름입니다: ",existingNames);
+            throw new DuplicateResourceException("이미 존재하는 테이블 이름입니다: ", existingNames);
         }
 
         // 중복 없으면 저장
@@ -59,5 +59,25 @@ public class StoreTableService {
     }
 
 
+    @Transactional(readOnly = true)
+    public List<StoreTableListResDTO> getStoreTableList(String storeLoginId) {
+        Store store = storeRepository.findByLoginId(storeLoginId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매장을 찾을 수 없습니다."));
+
+        List<Zone> zoneList = zoneRepository.findAllByStoreLoginId(storeLoginId);
+        List<StoreTableListResDTO> storeTableListResDTOList = new ArrayList<>();
+        for (Zone zone : zoneList) {
+            List<StoreTable> storeTableList = storeTableRepository.findAllByZone(zone);
+            List<StoreTableDetail> storeTableDetails = storeTableList.stream().map(StoreTableDetail::from).collect(Collectors.toList());
+            storeTableListResDTOList.add(StoreTableListResDTO.from(zone, storeTableDetails));
+        }
+
+        return storeTableListResDTOList;
+    }
+
+
+
 
 }
+
+


### PR DESCRIPTION
### 📋 작업 개요
전체 테이블 리스트 조회 api 구현

<br/>


### 🔧 작업 상세
- 각 매장의 구역별 전체 테이블 조회 API를 구현하였습니다.
- 응답 객체를 구역별 테이블 형식으로 정리했습니다.
<img width="781" height="387" alt="스크린샷 2025-08-01 오전 12 20 36" src="https://github.com/user-attachments/assets/73bf4cea-d867-4c1d-94b0-871248bd9858" />

<br/>


### 📌 이슈 번호
close #31

<br/>


### ⚠️ 참고사항
- 현 로직은 N+1 문제가 발생되기에 추후 fetch join을 도입하려고 하려고 합니다.
- fetch join으로 인한 해결은 8.2일까지 완료 예정입니다.
<img width="1123" height="217" alt="스크린샷 2025-07-31 오후 11 40 54" src="https://github.com/user-attachments/assets/8d5ebae0-8c1b-4cef-ad01-0340ae07e2ba" />


<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.