### PR TITLE
[Feat] 카테고리 불러오기 API 구현 (#52)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
@@ -3,14 +3,14 @@ package com.beyond.jellyorder.domain.category.controller;
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.category.dto.CategoryCreateReqDto;
 import com.beyond.jellyorder.domain.category.dto.CategoryCreateResDto;
+import com.beyond.jellyorder.domain.category.dto.GetCategoryResDto;
 import com.beyond.jellyorder.domain.category.service.CategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 카테고리 관련 요청을 처리하는 REST 컨트롤러 클래스.
@@ -41,5 +41,16 @@ public class CategoryController {
 
         // 표준 API 응답 포맷으로 반환 (201 Created)
         return ApiResponse.created(resDto, reqDto.getName() + " 카테고리가 정상적으로 저장되었습니다.");
+    }
+
+    @GetMapping("/store/{storeId}")
+    public ResponseEntity<?> getCategoriesByStore(@PathVariable String storeId) {
+
+        // TODO: 추후 로그인 기능 구현 시 SecurityContext에서 사용자 인증 정보를 추출하여 storeId를 검증할 예정
+        // 현재는 storeId를 URL로 직접 받아오기 때문에 보안상 노출 가능성이 있으나,
+        // 로그인 및 권한 검증이 추가되면 안전하게 처리될 예정입니다.
+
+        List<GetCategoryResDto> resDtoList = categoryService.getCategoriesByStore(storeId);
+        return ApiResponse.ok(resDtoList, "카테고리 목록이 정상적으로 조회되었습니다.");
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/dto/CategoryCreateReqDto.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.util.UUID;
+
 /**
  * 카테고리 생성 요청을 위한 DTO 클래스.
  * 클라이언트가 카테고리를 생성할 때 전달해야 할 필드들을 정의하며,

--- a/src/main/java/com/beyond/jellyorder/domain/category/dto/GetCategoryResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/dto/GetCategoryResDto.java
@@ -1,0 +1,13 @@
+package com.beyond.jellyorder.domain.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class GetCategoryResDto {
+    private UUID id;
+    private String name;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.category.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +11,5 @@ public interface CategoryRepository extends JpaRepository<Category, UUID>, Categ
     boolean existsByStoreIdAndName(String storeId, String name); // 임시 String storeId. **추후 UUID로 변경 필수**
     Optional<Category> findByIdAndStoreId(UUID id, String storeId);
     Optional<Category> findByStoreIdAndName(String storeId, String name);
+    List<Category> findAllByStoreId(String storeId);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
@@ -3,8 +3,11 @@ package com.beyond.jellyorder.domain.category.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID>, CategoryRepositoryCustom{
     boolean existsByStoreIdAndName(String storeId, String name); // 임시 String storeId. **추후 UUID로 변경 필수**
+    Optional<Category> findByIdAndStoreId(UUID id, String storeId);
+    Optional<Category> findByStoreIdAndName(String storeId, String name);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
@@ -2,12 +2,17 @@ package com.beyond.jellyorder.domain.category.service;
 
 import com.beyond.jellyorder.domain.category.dto.CategoryCreateReqDto;
 import com.beyond.jellyorder.domain.category.dto.CategoryCreateResDto;
+import com.beyond.jellyorder.domain.category.dto.GetCategoryResDto;
 import com.beyond.jellyorder.domain.category.repository.CategoryRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.beyond.jellyorder.common.exception.DuplicateResourceException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 카테고리 관련 비즈니스 로직을 담당하는 서비스 클래스.
@@ -43,5 +48,23 @@ public class CategoryService {
                 .build());
 
         return new CategoryCreateResDto(saved.getId(), saved.getName(), saved.getDescription());
+    }
+
+    public List<GetCategoryResDto> getCategoriesByStore(String storeId) {
+        // TODO [2025-08-02]: storeId 유효성 검증 (인증된 점주의 storeId인지 확인)
+
+        if (storeId == null || storeId.trim().isEmpty()) {
+            throw new IllegalArgumentException("storeId는 null이거나 공백일 수 없습니다.");
+        }
+
+        List<Category> categoryList = categoryRepository.findAllByStoreId(storeId);
+
+        if (categoryList.isEmpty()) {
+            throw new EntityNotFoundException("해당 storeId에 대한 카테고리가 존재하지 않습니다: " + storeId);
+        }
+
+        return categoryList.stream()
+                .map(category -> new GetCategoryResDto(category.getId(), category.getName()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
@@ -1,9 +1,11 @@
 package com.beyond.jellyorder.domain.ingredient.repository;
 
+import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -16,4 +18,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, UUID>, I
      * @return 존재 여부
      */
     boolean existsByStoreIdAndName(String storeId, String name);  // TODO: UUID로 교체
+    Optional<Ingredient> findByStoreIdAndName(String storeId, String name);
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -1,0 +1,33 @@
+package com.beyond.jellyorder.domain.menu.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
+import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
+import com.beyond.jellyorder.domain.menu.service.MenuService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 메뉴 관련 요청을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/menu")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    /**
+     * 새로운 메뉴 등록
+     */
+    @PostMapping("/create")
+    public ResponseEntity<?> createMenu(
+            @ModelAttribute @Valid MenuCreateReqDto reqDto) {
+
+        MenuCreateResDto resDto = menuService.create(reqDto);
+        return ApiResponse.created(resDto, resDto.getName() + " 메뉴가 정상적으로 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
@@ -1,0 +1,48 @@
+package com.beyond.jellyorder.domain.menu.domain;
+
+import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
+import com.beyond.jellyorder.domain.category.domain.Category;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "menu")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Menu extends BaseIdAndTimeEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(length = 30, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(length = 255, nullable = false)
+    private String description;
+
+    @Column(name = "image_url", length = 512, nullable = false)
+    private String imageUrl;
+
+    @Column(length = 255)
+    private String origin;
+
+    @Builder.Default
+    @Column(name = "sales_limit", nullable = false)
+    private Long salesLimit = -1L;
+
+    @Builder.Default
+    @Column(name = "sales_today", nullable = false)
+    private Integer salesToday = 0;
+
+//    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<MenuIngredient> menuIngredients;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredient.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredient.java
@@ -1,0 +1,29 @@
+package com.beyond.jellyorder.domain.menu.domain;
+
+import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "menu_ingredient")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MenuIngredient {
+
+    @EmbeddedId
+    private MenuIngredientId id;
+
+    // FK 관계 제거: 주석 처리
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @MapsId("menuId")
+    // @JoinColumn(name = "menu_id", referencedColumnName = "id", insertable = false, updatable = false)
+    // private Menu menu;
+
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @MapsId("ingredientId")
+    // @JoinColumn(name = "ingredient_id", referencedColumnName = "id", insertable = false, updatable = false)
+    // private Ingredient ingredient;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredientId.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredientId.java
@@ -1,0 +1,24 @@
+package com.beyond.jellyorder.domain.menu.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuIngredientId implements Serializable {
+
+    @Column(name = "menu_id", columnDefinition = "BINARY(16)")
+    private UUID menuId;
+
+    @Column(name = "ingredient_id", columnDefinition = "BINARY(16)")
+    private UUID ingredientId;
+
+    // equals, hashCode 반드시 구현해야 함
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
@@ -1,0 +1,47 @@
+package com.beyond.jellyorder.domain.menu.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MenuCreateReqDto {
+
+    @NotNull(message = "매장 ID(storeId)는 필수입니다.")
+    private String storeId;
+
+    @NotNull(message = "카테고리명은 필수입니다.")
+    private String categoryName;
+
+    @NotBlank(message = "메뉴 이름(name)은 필수입니다.")
+    @Size(max = 30, message = "메뉴 이름은 30자 이하로 입력해주세요.")
+    private String name;
+
+    @NotNull(message = "가격(price)은 필수입니다.")
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+    private Integer price;
+
+    @NotBlank(message = "설명(description)은 필수입니다.")
+    @Size(max = 255, message = "설명은 255자 이하로 입력해주세요.")
+    private String description;
+
+    @Size(max = 255, message = "원산지(origin)는 255자 이하로 입력해주세요.")
+    private String origin;
+
+    @Min(value = -1, message = "판매 한도는 -1 이상이어야 합니다.")
+    private Long salesLimit = -1L;
+
+    @Builder.Default
+    private List<String> ingredients = new ArrayList<>();
+
+    @NotNull(message = "이미지 파일(imageFile)은 필수입니다.")
+    private MultipartFile imageFile;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateResDto.java
@@ -1,0 +1,17 @@
+package com.beyond.jellyorder.domain.menu.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuCreateResDto {
+    private UUID id;
+    private String name;
+    private Integer price;
+    private String imageUrl;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuIngredientRepository.java
@@ -1,0 +1,8 @@
+package com.beyond.jellyorder.domain.menu.repository;
+
+import com.beyond.jellyorder.domain.menu.domain.MenuIngredient;
+import com.beyond.jellyorder.domain.menu.domain.MenuIngredientId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, MenuIngredientId> {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,11 @@
+package com.beyond.jellyorder.domain.menu.repository;
+
+import com.beyond.jellyorder.domain.category.domain.Category;
+import com.beyond.jellyorder.domain.menu.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuRepository  extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepositoryCustom.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.menu.repository;
+
+public interface MenuRepositoryCustom {
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepositoryCustomImpl.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepositoryCustomImpl.java
@@ -1,0 +1,4 @@
+package com.beyond.jellyorder.domain.menu.repository;
+
+public class MenuRepositoryCustomImpl implements MenuRepositoryCustom{
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -1,0 +1,100 @@
+package com.beyond.jellyorder.domain.menu.service;
+
+import com.beyond.jellyorder.common.s3.S3Manager;
+import com.beyond.jellyorder.domain.category.domain.Category;
+import com.beyond.jellyorder.domain.category.repository.CategoryRepository;
+import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
+import com.beyond.jellyorder.domain.ingredient.repository.IngredientRepository;
+import com.beyond.jellyorder.domain.menu.domain.Menu;
+import com.beyond.jellyorder.domain.menu.domain.MenuIngredient;
+import com.beyond.jellyorder.domain.menu.domain.MenuIngredientId;
+import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
+import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
+import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import com.beyond.jellyorder.domain.menu.repository.MenuIngredientRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final CategoryRepository categoryRepository;
+    private final IngredientRepository ingredientRepository;
+    private final MenuIngredientRepository menuIngredientRepository;
+    private final S3Manager s3Manager;
+
+    public MenuCreateResDto create(MenuCreateReqDto reqDto) {
+        Category category = categoryRepository.findByStoreIdAndName(reqDto.getStoreId(), reqDto.getCategoryName())
+                .orElseThrow(() -> new EntityNotFoundException("카테고리 조회 실패: name=" +
+                        reqDto.getCategoryName() + ", storeId=" + reqDto.getStoreId()));
+
+        MultipartFile imageFile = reqDto.getImageFile();
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new IllegalArgumentException("메뉴 이미지 파일이 누락되었습니다.");
+        }
+
+        String imageUrl = null;
+        Menu menu = null;
+
+        try {
+            // S3에 이미지 업로드
+            imageUrl = s3Manager.upload(imageFile, "menus");
+
+            // 메뉴 엔티티 생성 및 저장
+            menu = Menu.builder()
+                    .category(category)
+                    .name(reqDto.getName())
+                    .price(reqDto.getPrice())
+                    .description(reqDto.getDescription())
+                    .imageUrl(imageUrl)
+                    .origin(reqDto.getOrigin())
+                    .salesLimit(reqDto.getSalesLimit() != null ? reqDto.getSalesLimit() : -1L)
+                    .salesToday(0)
+                    .build();
+
+            menu = menuRepository.save(menu); // UUID 생성 후 menu.id 확보
+
+            // 식자재명 리스트에서 ID만 추출해서 MenuIngredient 구성
+            List<String> ingredientNames = reqDto.getIngredients() != null ? reqDto.getIngredients() : Collections.emptyList();
+
+            Menu finalMenu = menu;
+            List<MenuIngredient> menuIngredients = ingredientNames.stream().map(ingredientName -> {
+                Ingredient ingredient = ingredientRepository.findByStoreIdAndName(reqDto.getStoreId(), ingredientName)
+                        .orElseThrow(() -> new EntityNotFoundException("식자재를 찾을 수 없습니다: name=" + ingredientName));
+
+                return MenuIngredient.builder()
+                        .id(new MenuIngredientId(finalMenu.getId(), ingredient.getId()))
+                        // .menu(menu)          // FK 주석 처리
+                        // .ingredient(ingredient) // FK 주석 처리
+                        .build();
+            }).collect(Collectors.toList());
+
+            // MenuIngredientRepository를 따로 만들었다면 saveAll(menuIngredients)로 저장
+            menuIngredientRepository.saveAll(menuIngredients);
+
+        } catch (Exception e) {
+            if (imageUrl != null) {
+                s3Manager.delete(imageUrl);
+            }
+            throw e;
+        }
+
+        return MenuCreateResDto.builder()
+                .id(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .imageUrl(menu.getImageUrl())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
카테고리 목록 조회 API 구현 (storeId 기준으로 필터링된 카테고리 리스트 반환)

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- CategoryService에 getCategoriesByStore(String storeId) 메서드 구현
  - storeId 유효성 검사 (null, 공백, 존재 여부 확인)
  - 존재하지 않을 경우 EntityNotFoundException 발생
- CategoryRepository에 findAllByStoreId(String storeId) 쿼리 메서드 추가
- CategoryController에 @GetMapping("/store/{storeId}") 엔드포인트 추가
  - 인증/인가 미적용 상태이며 추후 SecurityContext에서 사용자 정보 추출 예정
  - 현재는 테스트 목적상 URL 경로에서 storeId를 직접 받는 방식 유지
- 응답 DTO GetCategoryResDto 클래스 생성
  - UUID id, String name 포함, @Getter, @AllArgsConstructor 적용
  - Service → Controller → Client 데이터 전달 포맷 담당
- 전체적으로 코드 정리 및 주석 보강 (TODO 및 보안 관련 설명 포함)
<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #52 
<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 현재 storeId는 String 형태로 처리 중이며, 추후 UUID 타입으로 변경 예정
- 로그인 및 보안 기능이 구현되면, 인증된 사용자의 storeId를 기반으로 필터링 예정
<br/>

### 테스트 결과:
<img width="2008" height="1134" alt="image" src="https://github.com/user-attachments/assets/0cdc9413-c2f6-4191-9a58-7bab7a0f57fe" />
<img width="1238" height="654" alt="image" src="https://github.com/user-attachments/assets/1bde8c46-468f-4bf3-9ac9-9e95d496bc57" />

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.