### PR TITLE
Feature56

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'  // JSON 처리에 필요
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+//	redis 관련 의존성 추가
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/com/beyond/jellyorder/common/auth/AuthService.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/AuthService.java
@@ -1,0 +1,45 @@
+package com.beyond.jellyorder.common.auth;
+
+import com.beyond.jellyorder.domain.store.entity.Store;
+import com.beyond.jellyorder.domain.store.repository.StoreRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+
+@Component
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final StoreRepository storeRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.secretKeyRt}")
+    private String secretKeyRt;
+    private Key secret_rt_key;
+
+    public Store validateStoreRt(String refreshToken) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKeyRt)
+                .build()
+                .parseClaimsJws(refreshToken)
+                .getBody();
+
+        String loginId = claims.getSubject();
+        Store store = storeRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new EntityNotFoundException("찾고자 하는 아이디가 없음"));
+
+//        redis의 값과 비교하는 검증
+        String redisRt = redisTemplate.opsForValue().get(store.getLoginId());
+        if (!redisRt.equals(refreshToken)) {
+            throw new IllegalArgumentException("잘못된 토큰값입니다.");
+        }
+        return store;
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenFilter.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenFilter.java
@@ -1,0 +1,52 @@
+package com.beyond.jellyorder.common.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component // (service 와 유사한 성격)
+@Slf4j
+public class JwtTokenFilter extends GenericFilter {
+
+    @Value("${jwt.secretKeyAt}")
+    private String secretKey;
+    //    token이 없는 경우 그냥 진행 시켜
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            HttpServletRequest req = (HttpServletRequest) servletRequest;
+            String bearerToken = req.getHeader("Authorization");
+            if (bearerToken == null) {
+                filterChain.doFilter(servletRequest, servletResponse);
+                return;
+            }
+            String token = bearerToken.substring(7);
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            List<GrantedAuthority> authorities = new ArrayList<>();
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + claims.get("role")));
+            Authentication authentication = new UsernamePasswordAuthenticationToken(claims.getSubject(), "", authorities);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenProvider.java
@@ -1,0 +1,94 @@
+package com.beyond.jellyorder.common.auth;
+
+import com.beyond.jellyorder.domain.store.entity.Store;
+import com.beyond.jellyorder.domain.store.repository.StoreRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+
+public class JwtTokenProvider {
+    private final StoreRepository storeRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.expirationAt}")
+    private int expirationAt;
+    @Value("${jwt.secretKeyAt}")
+    private String secretKeyAt;
+
+    @Value("${jwt.expirationRt}")
+    private int expirationRt;
+    @Value("${jwt.secretKeyRt}")
+    private String secretKeyRt;
+
+    private Key secret_at_key;
+    private Key secret_rt_key;
+
+    @Autowired
+    public JwtTokenProvider(StoreRepository storeRepository, @Qualifier("rtInventory") RedisTemplate<String, String> redisTemplate) {
+        this.storeRepository = storeRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @PostConstruct
+    public void init() {
+        secret_at_key = new SecretKeySpec
+                (java.util.Base64.getDecoder().decode(secretKeyAt), // 인코딩 된 걸 디코딩
+                SignatureAlgorithm.HS512.getJcaName()); // decode + algorithm 세팅
+        secret_rt_key = new SecretKeySpec
+                (java.util.Base64.getDecoder().decode(secretKeyRt),
+                        SignatureAlgorithm.HS512.getJcaName());
+    }
+
+    public String createStoreAtToken(Store store) {
+        String loginId = store.getLoginId();
+        String role = store.getRole().toString();
+
+        Claims claims = Jwts.claims().setSubject(loginId); // filter에서 claims.getSubject와 싱크, loginId
+        claims.put("role", role);
+        Date now = new Date();
+        String accessToken = Jwts.builder() // 토큰 제작
+                .setClaims(claims) // loginId + role STORE
+                .setIssuedAt(now) // 발행시간
+                .setExpiration(new Date(now.getTime() + expirationAt*60*1000L)) // 만료시간, 1000분
+                .signWith(secret_at_key)
+                .compact();
+
+        return accessToken;
+}
+
+    public String createStoreRtToken(Store store) {
+//        유효기간이 긴 rt 토큰 생성
+        String loginId = store.getLoginId();
+        String role = store.getRole().toString();
+
+        Claims claims = Jwts.claims().setSubject(loginId); // filter에서 claims.getSubject와 싱크, loginId
+        claims.put("role", role);
+        Date now = new Date();
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now) // 발행시간
+                .setExpiration(new Date(now.getTime() + expirationRt*60*1000L)) // 만료시간, 10000분 설정
+                .signWith(secret_rt_key)
+                .compact();
+
+        redisTemplate.opsForValue().set(store.getLoginId(), refreshToken);
+
+        return refreshToken;
+    }
+
+
+
+}

--- a/src/main/java/com/beyond/jellyorder/common/auth/RefreshTokenDto.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/RefreshTokenDto.java
@@ -1,0 +1,12 @@
+package com.beyond.jellyorder.common.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.common.auth;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -10,16 +11,26 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenFilter jwtTokenFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                /* chain 추가 예정, Security 의존성으로 인한 Req 막힘 방지 */
+                .cors(c -> c.configurationSource(corsConfiguration()))
                 .csrf(AbstractHttpConfigurer::disable) // 비브라우저, 토큰로그인을 위한 csrf disable
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(a -> a.requestMatchers("/store/create", "/store/doLogin", "/storetable/doLogin").permitAll().anyRequest().authenticated())
                 .build();
                 }
@@ -27,5 +38,16 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    private CorsConfigurationSource corsConfiguration(){
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000")); // 원하는 도메인 커스텀
+        configuration.setAllowedMethods(Arrays.asList("*")); // 모든 HTTP(get, post, patch 등) 메서드 허용
+        configuration.setAllowedHeaders(Arrays.asList("*")); // 모든 헤더요소(Authorization 등) 허용
+        configuration.setAllowCredentials(true); // 자격 증명 허용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); //모든 url패턴에 대해 cors설정 적용, ** : 모든계층구조
+        return source; // 모든 정책이 들어가 있음
     }
 }

--- a/src/main/java/com/beyond/jellyorder/config/RedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.beyond.jellyorder.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+    @Value("${spring.redis.port}")
+    private int port;
+
+    /* RefreshToken Redis에 저장하기 위한 Factory, 0번에 설정하였으나 추후 변경 가능 합니다! */
+    @Bean
+    @Qualifier("rtInventory")
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        configuration.setDatabase(0);
+
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    /* RefreshToken RedisTemplate */
+    @Bean
+    @Qualifier("rtInventory")
+    public RedisTemplate<String, String> redisTemplate(@Qualifier("rtInventory") RedisConnectionFactory redisConnectionFactory) { // 0번 팩토리 (Bean)싱글톤 객체로 주입 받겠다
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
@@ -1,12 +1,15 @@
 package com.beyond.jellyorder.domain.store.controller;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.common.auth.JwtTokenProvider;
 import com.beyond.jellyorder.domain.store.dto.LoginRequestDto;
+import com.beyond.jellyorder.domain.store.dto.LoginResponseDto;
 import com.beyond.jellyorder.domain.store.dto.StoreCreateDto;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.service.StoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +24,7 @@ import java.util.UUID;
 
 public class StoreController {
     private final StoreService storeService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /* Store 회원가입 Controller */
     @PostMapping("/create")
@@ -32,8 +36,17 @@ public class StoreController {
     @PostMapping("/doLogin")
     public ResponseEntity<?> doLogin(@RequestBody @Valid LoginRequestDto loginRequestDto) {
         Store store = storeService.doLogin(loginRequestDto);
-        return ApiResponse.ok("로그인 완료, 추후 토큰 발급 시 토큰 리턴 예정입니다.");
+        String storeAccessToken = jwtTokenProvider.createStoreAtToken(store);
+        String storeRefreshToken = jwtTokenProvider.createStoreRtToken(store);
+
+        LoginResponseDto loginResponseDto = LoginResponseDto.builder()
+                .accessToken(storeAccessToken)
+                .refreshToken(storeRefreshToken)
+                .build();
+
+        return ApiResponse.ok(loginResponseDto, "로그인 완료");
     }
+
 
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
@@ -1,7 +1,9 @@
 package com.beyond.jellyorder.domain.store.controller;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.common.auth.AuthService;
 import com.beyond.jellyorder.common.auth.JwtTokenProvider;
+import com.beyond.jellyorder.common.auth.RefreshTokenDto;
 import com.beyond.jellyorder.domain.store.dto.LoginRequestDto;
 import com.beyond.jellyorder.domain.store.dto.LoginResponseDto;
 import com.beyond.jellyorder.domain.store.dto.StoreCreateDto;
@@ -10,6 +12,7 @@ import com.beyond.jellyorder.domain.store.service.StoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,7 @@ import java.util.UUID;
 public class StoreController {
     private final StoreService storeService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthService authService;
 
     /* Store 회원가입 Controller */
     @PostMapping("/create")
@@ -45,6 +49,18 @@ public class StoreController {
                 .build();
 
         return ApiResponse.ok(loginResponseDto, "로그인 완료");
+    }
+
+    @PostMapping("/refresh-at")
+    public ResponseEntity<?> generateNewAt(@RequestBody RefreshTokenDto refreshTokenDto) {
+        Store store = authService.validateStoreRt(refreshTokenDto.getRefreshToken());
+
+        String accessToken = jwtTokenProvider.createStoreAtToken(store);
+        LoginResponseDto loginResponseDto = LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+
+        return ApiResponse.ok("StoreAccessToken 발급 성공"); /* 프론트 개발 후 리턴 값 변경 예정*/
     }
 
 

--- a/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.store.controller;
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.store.dto.LoginRequestDto;
 import com.beyond.jellyorder.domain.store.dto.StoreCreateDto;
+import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.service.StoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class StoreController {
 
     @PostMapping("/doLogin")
     public ResponseEntity<?> doLogin(@RequestBody @Valid LoginRequestDto loginRequestDto) {
-        String log = storeService.doLogin(loginRequestDto);
+        Store store = storeService.doLogin(loginRequestDto);
         return ApiResponse.ok("로그인 완료, 추후 토큰 발급 시 토큰 리턴 예정입니다.");
     }
 

--- a/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
@@ -1,10 +1,8 @@
 package com.beyond.jellyorder.domain.store.entity;
 
 import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.beyond.jellyorder.common.auth.Role;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,5 +33,8 @@ public class Store extends BaseIdAndTimeEntity {
     private String password;
     @Column(nullable = false)
     private String ownerEmail;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.STORE;
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
@@ -40,13 +40,16 @@ public class StoreService {
         return store.getId(); /* 리턴값 UUID로 수정 완료, 주석 삭제 하고 사용하세요! */
     }
 
-    public String doLogin(LoginRequestDto loginRequestDto) {
+    /* Store 로그인 Service*/
+    public Store doLogin(LoginRequestDto loginRequestDto) {
         Store store = storeRepository.findByLoginId(loginRequestDto.getLoginId())
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
-        if (!passwordEncoder.matches(loginRequestDto.getPassword(), store.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 틀립니다.");
+                .orElseThrow(() -> new EntityNotFoundException("아이디!! 또는 비밀번호가 일치하지 않습니다.")) ; // 로그인 정보가 일치하지 않습니다, 통일 예정
+        if (!passwordEncoder.matches(loginRequestDto.getPassword(), store.getPassword())){
+            throw new IllegalArgumentException("아이디 또는 비밀번호!!가 일치하지 않습니다."); // 로그인 정보가 일치하지 않습니다, 통일 예정
         }
-        return loginRequestDto.getLoginId(); // 나중에 At, Rt 리턴으로 수정 예정
+        return store;
+
+
     }
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
@@ -43,9 +43,9 @@ public class StoreService {
     /* Store 로그인 Service*/
     public Store doLogin(LoginRequestDto loginRequestDto) {
         Store store = storeRepository.findByLoginId(loginRequestDto.getLoginId())
-                .orElseThrow(() -> new EntityNotFoundException("아이디!! 또는 비밀번호가 일치하지 않습니다.")) ; // 로그인 정보가 일치하지 않습니다, 통일 예정
+                .orElseThrow(() -> new EntityNotFoundException("아이디!! 또는 비밀번호가 일치하지 않습니다.")) ; /* "로그인 정보가 일치하지 않습니다", 통일 예정 */
         if (!passwordEncoder.matches(loginRequestDto.getPassword(), store.getPassword())){
-            throw new IllegalArgumentException("아이디 또는 비밀번호!!가 일치하지 않습니다."); // 로그인 정보가 일치하지 않습니다, 통일 예정
+            throw new IllegalArgumentException("아이디 또는 비밀번호!!가 일치하지 않습니다."); /* "로그인 정보가 일치하지 않습니다", 통일 예정 */
         }
         return store;
 


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
Store 로그인 시, Accesstoken, Refreshtoken 발급
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- JwtTokenProvider 클래스 내, createStoreAtToken, createStoreRtToken 메서드를 활용하여 Store 로그인 시 
AccessToken, RefreshToken이 발급 되도록 하였습니다.

- JwtTokenProvider 클래스 내, init 메서드를 사용하였는데, 이는 Spring boot 내 암호화 라이브러리를 사용하기 위함입니다.
secret_at_key, secret_rt_key가 자동으로 발급 되도록 @PostConstruct 어노테이션을 활용하였습니다.

- validateRt, RefreshToken 검증은 책임의 분리를 위해 AuthService를 따로 만들어 분리하였습니다.

- secretAtKey, secretRtKey .yml파일에 추가하였습니다. .yml파일 내 어떤 문자열을 기반으로 인코딩을 했는지 주석에 달아놓았습니다.

- AccessToken의 만료시간은 1000분으로 설정하였으나, 추후 개발 완료 시 30분으로 제한할 예정입니다.

- RefreshToken의 만료시간은 10000분으로 설정하였으나, 추후 개발 완료 시 129600분(90일)으로 제한할 예정입니다. 

- Token 내 Payload는 loginId(subject, 주요키값), Role을 활용하였습니다.

- RefreshToken은 Redis를 활용하였고, database는 기본값인 0번에 설정하였습니다. 추후 개발을 진행하며 바꿀 예정입니다.
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #56 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- Redis 내 rtInventory의 database 번호는 '0번'입니다. 추후 협의하여 Redis database 번호를 정하는 것이 어떨까요?
- validateRt의 경우 책임 분리를 위해 provider 보단, 새로운 service 클래스를 만들어 제작하였습니다.


- 로그인 성공 시, return : at, rt 발급
<img width="672" height="506" alt="image" src="https://github.com/user-attachments/assets/aabe9ba5-05e6-4833-a567-3297b3259c66" />
<img width="1127" height="837" alt="image" src="https://github.com/user-attachments/assets/55a0462a-1b92-4388-896f-0a5cab42ea76" />

- RefreshToken을 기반으로 AccessToken재발급
<img width="1153" height="709" alt="image" src="https://github.com/user-attachments/assets/1a1c7d1f-3e81-446c-9c2f-abd475f61fa6" />


<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.