### PR TITLE
[Feat] 카테고리 삭제 API 구현 (#61)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/controller/CategoryController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * 카테고리 관련 요청을 처리하는 REST 컨트롤러 클래스.
@@ -52,5 +53,11 @@ public class CategoryController {
 
         List<GetCategoryResDto> resDtoList = categoryService.getCategoriesByStore(storeId);
         return ApiResponse.ok(resDtoList, "카테고리 목록이 정상적으로 조회되었습니다.");
+    }
+
+    @DeleteMapping("/delete/{storeId}/{categoryName}")
+    public ResponseEntity<?> deleteCategory(@PathVariable String storeId, @PathVariable String categoryName) {
+        categoryService.deleteCategory(storeId, categoryName);
+        return ApiResponse.ok(null, "카테고리가 정상적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
@@ -2,6 +2,9 @@ package com.beyond.jellyorder.domain.category.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +12,11 @@ import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID>, CategoryRepositoryCustom{
     boolean existsByStoreIdAndName(String storeId, String name); // 임시 String storeId. **추후 UUID로 변경 필수**
-    Optional<Category> findByIdAndStoreId(UUID id, String storeId);
     Optional<Category> findByStoreIdAndName(String storeId, String name);
     List<Category> findAllByStoreId(String storeId);
+
+    @Modifying
+    @Query("DELETE FROM Category c WHERE c.storeId = :storeId AND c.name = :name")
+    int deleteByStoreIdAndName(@Param("storeId") String storeId, @Param("name") String name);
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/service/CategoryService.java
@@ -5,7 +5,10 @@ import com.beyond.jellyorder.domain.category.dto.CategoryCreateResDto;
 import com.beyond.jellyorder.domain.category.dto.GetCategoryResDto;
 import com.beyond.jellyorder.domain.category.repository.CategoryRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
+import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,8 +25,10 @@ import java.util.stream.Collectors;
 @Transactional
 @RequiredArgsConstructor
 public class CategoryService {
-
+    @PersistenceContext
+    private EntityManager entityManager;
     private final CategoryRepository categoryRepository;
+    private final MenuRepository menuRepository;
 
     /**
      * 새로운 카테고리를 생성한다.
@@ -66,5 +71,21 @@ public class CategoryService {
         return categoryList.stream()
                 .map(category -> new GetCategoryResDto(category.getId(), category.getName()))
                 .collect(Collectors.toList());
+    }
+
+    public void deleteCategory(String storeId, String categoryName) {
+        // TODO [2025-08-02]: storeId 유효성 검증 (인증된 점주의 storeId인지 확인)
+
+        validateNoMenusExist(storeId, categoryName);
+        int deleted = categoryRepository.deleteByStoreIdAndName(storeId, categoryName);
+        if (deleted == 0) {
+            throw new EntityNotFoundException("삭제 대상 카테고리를 찾을 수 없습니다.");
+        }
+    }
+
+    private void validateNoMenusExist(String storeId, String categoryName) {
+        if (menuRepository.existsByCategory_StoreIdAndCategory_Name(storeId, categoryName)) {
+            throw new IllegalArgumentException("해당 카테고리에 소속된 메뉴가 존재하여 삭제할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface MenuRepository  extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
+    boolean existsByCategory_StoreIdAndCategory_Name(String storeId, String categoryName);
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
카테고리 삭제 기능 구현 및 안정성 개선
<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuRepository에 existsByCategory_StoreIdAndCategory_Name 메서드 추가
- CategoryService 내 삭제 로직 개선: 메뉴 존재 여부 확인 및 JPQL 기반 삭제 처리
- CategoryRepository에 @Modifying JPQL 삭제 쿼리 메서드 deleteByStoreIdAndName 추가
- CategoryController에 카테고리 삭제용 DELETE API 엔드포인트 추가
- EntityManager 제거 및 의존성 정리

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #61 

<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- storeId는 현재 String 타입으로 유지되며, 추후 UUID로 전환 예정
- StaleObjectStateException 방지를 위해 JPQL 삭제 쿼리 사용

### 테스트 결과:
<img width="1234" height="854" alt="image" src="https://github.com/user-attachments/assets/da690cab-33b4-49c3-9e9e-913ff5ecf4c6" />
<img width="1232" height="849" alt="image" src="https://github.com/user-attachments/assets/a14e94f4-c321-40e3-845c-9f371b56d82c" />
<img width="1227" height="845" alt="image" src="https://github.com/user-attachments/assets/c9e58a9d-fb3e-4718-83fb-425b3caaecce" />
<img width="1229" height="1081" alt="image" src="https://github.com/user-attachments/assets/af2bfd16-7b56-492c-9672-5099db006f2d" />
<img width="1226" height="1026" alt="image" src="https://github.com/user-attachments/assets/6a3dcde7-3af3-4f0a-a8b9-9e5eb5d2627e" />
<img width="1238" height="958" alt="image" src="https://github.com/user-attachments/assets/ed34cb66-0d5b-41a0-bb19-05afa2e37e20" />
<img width="1239" height="952" alt="image" src="https://github.com/user-attachments/assets/b5acd887-cd38-411c-ae32-de953fbabbd0" />
<img width="1225" height="940" alt="image" src="https://github.com/user-attachments/assets/19059146-df04-4fe5-89fb-3bd5a3838e79" />

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.