### PR TITLE
[Feat] 단일 메뉴 조회/메뉴 목록 조회 API 구현 (#64)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -30,4 +30,13 @@ public class MenuController {
         MenuCreateResDto resDto = menuService.create(reqDto);
         return ApiResponse.created(resDto, resDto.getName() + " 메뉴가 정상적으로 저장되었습니다.");
     }
+
+    @GetMapping("/store/{storeId}/name/{menuName}") // 추후 Authentication 도입 시 storeId 필요 X, menuName 대신 UUID를 body를 통해 전달 예정
+    public ResponseEntity<?> getMenuByStoreIdAndName(
+            @PathVariable String storeId,
+            @PathVariable String menuName) {
+
+        MenuCreateResDto resDto = menuService.getMenuByStoreIdAndName(storeId, menuName);
+        return ApiResponse.ok(resDto, "메뉴가 정상적으로 조회되었습니다.");
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 /**
  * 메뉴 관련 요청을 처리하는 컨트롤러
  */
@@ -37,6 +39,12 @@ public class MenuController {
             @PathVariable String menuName) {
 
         MenuCreateResDto resDto = menuService.getMenuByStoreIdAndName(storeId, menuName);
-        return ApiResponse.ok(resDto, "메뉴가 정상적으로 조회되었습니다.");
+        return ApiResponse.ok(resDto, "단일 메뉴 조회가 정상적으로 조회되었습니다.");
+    }
+
+    @GetMapping("/store/{storeId}")
+    public ResponseEntity<?> getMenusByStoreId(@PathVariable String storeId) {
+        List<MenuCreateResDto> resDtos = menuService.getMenusByStoreId(storeId);
+        return ApiResponse.ok(resDtos, "메뉴 목록이 정상적으로 조회되었습니다.");
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -1,12 +1,13 @@
 package com.beyond.jellyorder.domain.menu.repository;
 
-import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.menu.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MenuRepository  extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
     Optional<Menu> findByCategory_StoreIdAndName(String storeId, String name);
+    List<Menu> findAllByCategory_StoreId(String storeId);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface MenuRepository  extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
+    Optional<Menu> findByCategory_StoreIdAndName(String storeId, String name);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -96,5 +96,21 @@ public class MenuService {
                 .imageUrl(menu.getImageUrl())
                 .build();
     }
+
+    public MenuCreateResDto getMenuByStoreIdAndName(String storeId, String name) { // 추후 name 대신 UUID로 수정 예정
+
+        // TODO [2025-08-02]: storeId 유효성 검증 (인증된 점주의 storeId인지 확인)
+        // Auth 도입 후 검증 로직 추가 예정
+
+        Menu menu = menuRepository.findByCategory_StoreIdAndName(storeId, name)
+                .orElseThrow(() -> new EntityNotFoundException("해당 메뉴를 찾을 수 없습니다: name=" + name + ", storeId=" + storeId));
+
+        return MenuCreateResDto.builder()
+                .id(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .imageUrl(menu.getImageUrl())
+                .build();
+    }
 }
 

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -112,5 +112,23 @@ public class MenuService {
                 .imageUrl(menu.getImageUrl())
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public List<MenuCreateResDto> getMenusByStoreId(String storeId) {
+        List<Menu> menus = menuRepository.findAllByCategory_StoreId(storeId);
+
+        if (menus.isEmpty()) {
+            throw new EntityNotFoundException("해당 storeId에 대한 메뉴가 존재하지 않습니다: " + storeId);
+        }
+
+        return menus.stream()
+                .map(menu -> MenuCreateResDto.builder()
+                        .id(menu.getId())
+                        .name(menu.getName())
+                        .price(menu.getPrice())
+                        .imageUrl(menu.getImageUrl())
+                        .build())
+                .toList();
+    }
 }
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
storeId와 메뉴명을 기반으로 한 단일/다중 메뉴 조회 API 기능 구현

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
이번 작업에서는 매장의 고유 식별자인 storeId를 기준으로 단일 메뉴와 전체 메뉴를 각각 조회할 수 있는 기능을 구현하였습니다. 먼저 MenuRepository에 카테고리 연관 관계를 활용한 파생 쿼리 메서드인 findByCategory_StoreIdAndName과 findAllByCategory_StoreId를 추가하여, 메뉴 이름 기반 단건 조회와 매장 전체 메뉴 리스트 조회가 가능하도록 하였습니다.

이후 MenuService에서는 해당 쿼리 메서드를 호출하는 getMenuByStoreIdAndName과 getMenusByStoreId 메서드를 구현하여 각각 메뉴 한 건 또는 전체를 조회하고, 이를 DTO(MenuCreateResDto)로 매핑하여 반환하도록 구성했습니다. 예외 상황에 대한 처리를 명확히 하기 위해 메뉴가 존재하지 않을 경우에는 EntityNotFoundException을 발생시킵니다.

마지막으로 MenuController에는 RESTful한 API 설계 원칙에 따라 GET 요청으로 각각의 조회를 처리하는 두 개의 엔드포인트를 추가하였습니다. /menu/store/{storeId}/name/{menuName} 경로는 단일 메뉴 조회를, /menu/store/{storeId} 경로는 전체 메뉴 목록 조회를 담당합니다. 단건 조회 메시지는 사용자 입장에서 의미가 명확하도록 "단일 메뉴 조회가 정상적으로 조회되었습니다."로 수정하였습니다.
<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #64 
<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 현재는 storeId를 String 타입의 PathVariable로 전달받고 있으나, 추후 인증(Authentication) 기능이 도입되면 인증된 사용자 정보에서 추출하는 방식으로 리팩토링될 예정입니다.
- menuName은 현재 식별자로 사용되고 있으나, 향후에는 UUID 등 고유 키로 대체될 계획입니다.
- 단건 조회와 목록 조회는 현재 MenuCreateResDto를 공통적으로 사용하고 있으며, 추후 상세 조회 기능이 추가되면 MenuDetailResDto 등으로 확장 가능성이 있습니다.

### 테스트 결과:
<img width="1233" height="1077" alt="image" src="https://github.com/user-attachments/assets/7a3f30e1-57ba-4365-8441-ef073d29825a" />
<img width="1227" height="952" alt="image" src="https://github.com/user-attachments/assets/0a8c161e-fcd5-45a2-8d1e-29d94e869822" />
<img width="1237" height="1126" alt="image" src="https://github.com/user-attachments/assets/a7a75135-03b0-4495-ac90-49f31651841e" />
<img width="1226" height="779" alt="image" src="https://github.com/user-attachments/assets/23e3c0bf-22ec-40ff-ad04-354c8a691d05" />

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.