### PR TITLE
[Fix] RedisConfig 클래스 명 중복 충돌로 인한 긴급 클래스명 변경

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/auth/AuthService.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/AuthService.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Jwts;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Component;
 import java.security.Key;
 
 @Component
-@RequiredArgsConstructor
 public class AuthService {
 
     private final StoreRepository storeRepository;
@@ -23,6 +23,11 @@ public class AuthService {
     @Value("${jwt.secretKeyRt}")
     private String secretKeyRt;
     private Key secret_rt_key;
+
+    public AuthService(StoreRepository storeRepository, @Qualifier("rtInventoryTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.storeRepository = storeRepository;
+        this.redisTemplate = redisTemplate;
+    }
 
     public Store validateStoreRt(String refreshToken) {
         Claims claims = Jwts.parserBuilder()

--- a/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/JwtTokenProvider.java
@@ -37,7 +37,7 @@ public class JwtTokenProvider {
     private Key secret_rt_key;
 
     @Autowired
-    public JwtTokenProvider(StoreRepository storeRepository, @Qualifier("rtInventory") RedisTemplate<String, String> redisTemplate) {
+    public JwtTokenProvider(StoreRepository storeRepository, @Qualifier("rtInventoryTemplate") RedisTemplate<String, String> redisTemplate) {
         this.storeRepository = storeRepository;
         this.redisTemplate = redisTemplate;
     }

--- a/src/main/java/com/beyond/jellyorder/config/AuthRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/config/AuthRedisConfig.java
@@ -18,8 +18,7 @@ public class AuthRedisConfig {
     private int port;
 
     /* RefreshToken Redis에 저장하기 위한 Factory, 0번에 설정하였으나 추후 변경 가능 합니다! */
-    @Bean
-    @Qualifier("rtInventory")
+    @Bean(name = "rtInventory")
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
         configuration.setHostName(host);
@@ -30,9 +29,17 @@ public class AuthRedisConfig {
     }
 
     /* RefreshToken RedisTemplate */
-    @Bean
-    @Qualifier("rtInventory")
+    @Bean(name = "rtInventoryTemplate")
     public RedisTemplate<String, String> redisTemplate(@Qualifier("rtInventory") RedisConnectionFactory redisConnectionFactory) { // 0번 팩토리 (Bean)싱글톤 객체로 주입 받겠다
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean(name = "redisTemplate") /* redisTemplate 기본 이름을 찾기 위해 주입 */
+    public RedisTemplate<String, String> defaultRedisTemplate(@Qualifier("rtInventory") RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());

--- a/src/main/java/com/beyond/jellyorder/config/AuthRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/config/AuthRedisConfig.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-public class RedisConfig {
+public class AuthRedisConfig {
     @Value("${spring.redis.host}")
     private String host;
     @Value("${spring.redis.port}")

--- a/src/main/java/com/beyond/jellyorder/sseRequest/config/RedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/sseRequest/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.sseRequest.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,14 +20,14 @@ public class RedisConfig {
     private int port;
 
     // Redis 서버와 TCP 연결하는 클라이언트 커넥션 팩토리
-    @Bean
+    @Bean(name = "sseRedisConnectionFactory")
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
     }
 
     // RedisTemplate Bean : 데이터를 저장하고 조회하는 주요 도구
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+    @Bean(name = "sseRedisTemplate")
+    public RedisTemplate<String, Object> redisTemplate(@Qualifier("sseRedisConnectionFactory") RedisConnectionFactory factory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 

--- a/src/main/java/com/beyond/jellyorder/sseRequest/service/RedisRequestService.java
+++ b/src/main/java/com/beyond/jellyorder/sseRequest/service/RedisRequestService.java
@@ -5,6 +5,7 @@ import com.beyond.jellyorder.sseRequest.dto.RequestCreateDto;
 import com.beyond.jellyorder.sseRequest.repository.RequestRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
@@ -14,15 +15,20 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-@RequiredArgsConstructor
 // Redis에 실시간 요청 저장,조회,삭제
 public class RedisRequestService {
+    @Qualifier("sseRedisTemplate")
     private final RedisTemplate<String, Object> redisTemplate;
     private final StoreRepository storeRepository;
 
     // 필드 및 Redis 키 정의(순서와 데이터 조회를 동시에 보장)
     private static final String REQUEST_LIST_KEY = "request:list";  // 요청 ID들을 순서대로 저장하는 List 구조의 키
     private static final String REQUEST_HASH_KEY = "request:data";  // 각 요청 ID별로 상세 데이터를 저장하는 Hash 구조의 키
+
+    public RedisRequestService(@Qualifier("sseRedisTemplate") RedisTemplate<String, Object> redisTemplate, StoreRepository storeRepository) {
+        this.redisTemplate = redisTemplate;
+        this.storeRepository = storeRepository;
+    }
 
     // 고객 요청을 redis에 저장
     public void save(RequestCreateDto dto) {


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
RedisConfig 클래스 명 충돌로 인한 긴급 수정
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
RedisConfig -> AuthRedisConfig로 변경
추후 RedisConfig 클래스로 모을 예정

RedisTemplate 적용할 땐 @RequiredArgs를 사용하지 않고, 생성자 주입 방식을 사용해야 추후 충돌 방지 가능
@Quailifier(탬플릿 네임)를 사용하여 Spring에게 확실하게 명시해줘야 함

<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  

<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
앞으로 Redis를 사용할 땐 꼭!꼭! 생성자 주입방식을 사용해주세요
템플릿 네임도 굉장히 중요합니다. 일단은 긴급으로 머지 하겠습니다. 추후 RedisConfig를 모으도록 해요

한시간 반 동안 이것만 찾았습니다....
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.