### PR TITLE
[Feat] 메뉴 옵션 추가 API 구현 (#78)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -4,11 +4,12 @@ import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
 import com.beyond.jellyorder.domain.menu.service.MenuService;
+import com.beyond.jellyorder.domain.option.dto.OptionAddReqDto;
+import com.beyond.jellyorder.domain.option.dto.OptionAddResDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -47,4 +48,13 @@ public class MenuController {
         List<MenuCreateResDto> resDtos = menuService.getMenusByStoreId(storeId);
         return ApiResponse.ok(resDtos, "메뉴 목록이 정상적으로 조회되었습니다.");
     }
+
+    @PostMapping("/option/add")
+    public ResponseEntity<?> addOptionsToMenu(
+            @RequestBody @Valid OptionAddReqDto reqDto) {
+
+        OptionAddResDto resDto = menuService.addOptionsToMenu(reqDto);
+        return ApiResponse.ok(resDto, "옵션이 정상적으로 추가되었습니다.");
+    }
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
@@ -2,6 +2,7 @@ package com.beyond.jellyorder.domain.menu.domain;
 
 import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
 import com.beyond.jellyorder.domain.category.domain.Category;
+import com.beyond.jellyorder.domain.option.mainOption.domain.MainOption;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -43,6 +44,6 @@ public class Menu extends BaseIdAndTimeEntity {
     @Column(name = "sales_today", nullable = false)
     private Integer salesToday = 0;
 
-//    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<MenuIngredient> menuIngredients;
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MainOption> mainOptions;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
@@ -1,12 +1,12 @@
 package com.beyond.jellyorder.domain.menu.dto;
 
+import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Getter
 @Setter
@@ -44,4 +44,6 @@ public class MenuCreateReqDto {
 
     @NotNull(message = "이미지 파일(imageFile)은 필수입니다.")
     private MultipartFile imageFile;
+
+    private List<MainOptionDto> mainOptions;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateResDto.java
@@ -1,7 +1,9 @@
 package com.beyond.jellyorder.domain.menu.dto;
 
+import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
 import lombok.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -14,4 +16,5 @@ public class MenuCreateResDto {
     private String name;
     private Integer price;
     private String imageUrl;
+    private List<MainOptionDto> mainOptions;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -11,6 +11,8 @@ import com.beyond.jellyorder.domain.menu.domain.MenuIngredientId;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
 import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
+import com.beyond.jellyorder.domain.option.dto.OptionAddReqDto;
+import com.beyond.jellyorder.domain.option.dto.OptionAddResDto;
 import com.beyond.jellyorder.domain.option.mainOption.domain.MainOption;
 import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
 import com.beyond.jellyorder.domain.option.subOption.domain.SubOption;
@@ -37,10 +39,81 @@ public class MenuService {
     private final S3Manager s3Manager;
 
     public MenuCreateResDto create(MenuCreateReqDto reqDto) {
+        // 0) 카테고리 조회
         Category category = categoryRepository.findByStoreIdAndName(reqDto.getStoreId(), reqDto.getCategoryName())
-                .orElseThrow(() -> new EntityNotFoundException("카테고리 조회 실패: name=" +
-                        reqDto.getCategoryName() + ", storeId=" + reqDto.getStoreId()));
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "카테고리 조회 실패: name=" + reqDto.getCategoryName() + ", storeId=" + reqDto.getStoreId()));
 
+        // 1) 옵션 트리 사전 검증 & 메모리 구성 (이미지/DB 작업 전)
+        List<MainOption> preparedMainOptions = new ArrayList<>();
+        Set<String> mainNames = new HashSet<>();
+
+        List<MainOptionDto> mainOptionDtos = reqDto.getMainOptions();
+        if (mainOptionDtos != null && !mainOptionDtos.isEmpty()) {
+            for (int i = 0; i < mainOptionDtos.size(); i++) {
+                MainOptionDto mainDto = mainOptionDtos.get(i);
+
+                // 메인 옵션 이름 검증
+                String mainName = (mainDto.getName() == null) ? "" : mainDto.getName().trim();
+                if (mainName.isEmpty()) {
+                    throw new IllegalArgumentException("메인 옵션 이름은 필수입니다. (index=" + i + ")");
+                }
+                if (!mainNames.add(mainName)) {
+                    throw new IllegalArgumentException("중복된 메인 옵션 이름이 존재합니다: " + mainName);
+                }
+
+                MainOption mainOpt = MainOption.builder()
+                        .name(mainName)
+                        .build();
+
+                // 서브 옵션 검증
+                List<SubOption> subs = new ArrayList<>();
+                Set<String> subNames = new HashSet<>();
+                List<SubOptionDto> subDtos = mainDto.getSubOptions();
+
+                if (subDtos != null && !subDtos.isEmpty()) {
+                    for (int j = 0; j < subDtos.size(); j++) {
+                        SubOptionDto subDto = subDtos.get(j);
+
+                        String subName = (subDto.getName() == null) ? "" : subDto.getName().trim();
+                        if (subName.isEmpty()) {
+                            throw new IllegalArgumentException("서브 옵션 이름은 필수입니다. (main=" + mainName + ", index=" + j + ")");
+                        }
+                        if (!subNames.add(subName)) {
+                            throw new IllegalArgumentException("메인 옵션 '" + mainName + "'에 중복된 서브 옵션이 존재합니다: " + subName);
+                        }
+
+                        // 가격 필수 및 하한 검증
+                        Integer price = subDto.getPrice();
+                        if (price == null) {
+                            throw new IllegalArgumentException("서브 옵션 가격은 필수입니다. (main=" + mainName + ", sub=" + subName + ")");
+                        }
+                        if (price < 0) {
+                            throw new IllegalArgumentException("서브 옵션 가격은 0 이상이어야 합니다. (main=" + mainName + ", sub=" + subName + ")");
+                        }
+
+                        subs.add(SubOption.builder()
+                                .name(subName)
+                                .price(price)
+                                .build());
+                    }
+                }
+
+                mainOpt.setSubOptions(subs);
+                preparedMainOptions.add(mainOpt);
+            }
+        }
+
+        // 2) 식자재 존재 검증 (DB 조회만)
+        List<String> ingredientNames = Optional.ofNullable(reqDto.getIngredients()).orElse(Collections.emptyList());
+        List<Ingredient> ingredients = new ArrayList<>(ingredientNames.size());
+        for (String ingName : ingredientNames) {
+            Ingredient ing = ingredientRepository.findByStoreIdAndName(reqDto.getStoreId(), ingName)
+                    .orElseThrow(() -> new EntityNotFoundException("식자재를 찾을 수 없습니다: name=" + ingName));
+            ingredients.add(ing);
+        }
+
+        // 3) 이미지 검증 (최후순위)
         MultipartFile imageFile = reqDto.getImageFile();
         if (imageFile == null || imageFile.isEmpty()) {
             throw new IllegalArgumentException("메뉴 이미지 파일이 누락되었습니다.");
@@ -50,10 +123,10 @@ public class MenuService {
         Menu menu = null;
 
         try {
-            // S3에 이미지 업로드
+            // 4) 이미지 업로드 (검증 모두 통과 후)
             imageUrl = s3Manager.upload(imageFile, "menus");
 
-            // 메뉴 엔티티 생성 및 저장
+            // 5) 메뉴 저장
             menu = Menu.builder()
                     .category(category)
                     .name(reqDto.getName())
@@ -65,84 +138,63 @@ public class MenuService {
                     .salesToday(0)
                     .build();
 
-            menu = menuRepository.save(menu); // UUID 생성 후 menu.id 확보
+            menu = menuRepository.save(menu); // UUID 확보
 
-            // 식자재명 리스트에서 ID만 추출해서 MenuIngredient 구성
-            List<String> ingredientNames = reqDto.getIngredients() != null ? reqDto.getIngredients() : Collections.emptyList();
+            // 6) 옵션 트리에 역참조 연결 후 세팅 (cascade = ALL 이라고 가정)
+            for (MainOption mo : preparedMainOptions) {
+                mo.setMenu(menu);
+                if (mo.getSubOptions() != null) {
+                    for (SubOption so : mo.getSubOptions()) {
+                        so.setMainOption(mo);
+                    }
+                }
+            }
+            menu.setMainOptions(preparedMainOptions); // cascade로 함께 persist
 
-            Menu finalMenu = menu;
-            List<MenuIngredient> menuIngredients = ingredientNames.stream().map(ingredientName -> {
-                Ingredient ingredient = ingredientRepository.findByStoreIdAndName(reqDto.getStoreId(), ingredientName)
-                        .orElseThrow(() -> new EntityNotFoundException("식자재를 찾을 수 없습니다: name=" + ingredientName));
-
-                return MenuIngredient.builder()
-                        .id(new MenuIngredientId(finalMenu.getId(), ingredient.getId()))
-                        // .menu(menu)          // FK 주석 처리
-                        // .ingredient(ingredient) // FK 주석 처리
-                        .build();
-            }).collect(Collectors.toList());
-
-            // MenuIngredientRepository를 따로 만들었다면 saveAll(menuIngredients)로 저장
-            menuIngredientRepository.saveAll(menuIngredients);
+            // 7) MenuIngredient 저장
+            if (!ingredients.isEmpty()) {
+                Menu finalMenu = menu;
+                List<MenuIngredient> menuIngredients = ingredients.stream()
+                        .map(ing -> MenuIngredient.builder()
+                                .id(new MenuIngredientId(finalMenu.getId(), ing.getId()))
+                                .build())
+                        .collect(Collectors.toList());
+                menuIngredientRepository.saveAll(menuIngredients);
+            }
 
         } catch (Exception e) {
+            // 8) 실패 시 업로드 파일 정리
             if (imageUrl != null) {
                 s3Manager.delete(imageUrl);
             }
             throw e;
         }
 
-        List<MainOptionDto> mainOptionDtos = reqDto.getMainOptions();
-        if (mainOptionDtos != null && !mainOptionDtos.isEmpty()) {
-            List<MainOption> mainOptions = new ArrayList<>();
-            Set<String> mainOptionNames = new HashSet<>();
-
-            for (MainOptionDto mainDto : mainOptionDtos) {
-                String mainName = mainDto.getName();
-
-                // MainOption 이름 중복 체크
-                if (!mainOptionNames.add(mainName)) {
-                    throw new IllegalArgumentException("중복된 메인 옵션 이름이 존재합니다: " + mainName);
-                }
-
-                MainOption mainOption = MainOption.builder()
-                        .menu(menu)
-                        .name(mainName)
-                        .build();
-
-                List<SubOption> subOptions = new ArrayList<>();
-                Set<String> subOptionNames = new HashSet<>();
-
-                if (mainDto.getSubOptions() != null) {
-                    for (SubOptionDto subDto : mainDto.getSubOptions()) {
-                        String subName = subDto.getName();
-
-                        // SubOption 이름 중복 체크
-                        if (!subOptionNames.add(subName)) {
-                            throw new IllegalArgumentException("메인 옵션 '" + mainName + "'에 중복된 서브 옵션이 존재합니다: " + subName);
-                        }
-
-                        SubOption sub = SubOption.builder()
-                                .mainOption(mainOption)
-                                .name(subName)
-                                .build();
-
-                        subOptions.add(sub);
-                    }
-                }
-
-                mainOption.setSubOptions(subOptions);
-                mainOptions.add(mainOption);
-            }
-
-            menu.setMainOptions(mainOptions);
-        }
-
+        // 9) 응답 DTO
         return MenuCreateResDto.builder()
                 .id(menu.getId())
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .imageUrl(menu.getImageUrl())
+                .mainOptions(
+                        menu.getMainOptions() != null ?
+                                menu.getMainOptions().stream()
+                                        .map(main -> MainOptionDto.builder()
+                                                .name(main.getName())
+                                                .subOptions(
+                                                        main.getSubOptions() != null ?
+                                                                main.getSubOptions().stream()
+                                                                        .map(sub -> SubOptionDto.builder()
+                                                                                .name(sub.getName())
+                                                                                .price(sub.getPrice())
+                                                                                .build())
+                                                                        .toList()
+                                                                : List.of()
+                                                )
+                                                .build())
+                                        .toList()
+                                : List.of()
+                )
                 .build();
     }
 
@@ -159,6 +211,25 @@ public class MenuService {
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .imageUrl(menu.getImageUrl())
+                .mainOptions(
+                        menu.getMainOptions() != null ?
+                                menu.getMainOptions().stream()
+                                        .map(main -> MainOptionDto.builder()
+                                                .name(main.getName())
+                                                .subOptions(
+                                                        main.getSubOptions() != null ?
+                                                                main.getSubOptions().stream()
+                                                                        .map(sub -> SubOptionDto.builder()
+                                                                                .name(sub.getName())
+                                                                                .price(sub.getPrice())
+                                                                                .build())
+                                                                        .toList()
+                                                                : List.of()
+                                                )
+                                                .build())
+                                        .toList()
+                                : List.of()
+                )
                 .build();
     }
 
@@ -176,8 +247,82 @@ public class MenuService {
                         .name(menu.getName())
                         .price(menu.getPrice())
                         .imageUrl(menu.getImageUrl())
+                        .mainOptions(
+                                menu.getMainOptions() != null ?
+                                        menu.getMainOptions().stream().map(main -> MainOptionDto.builder()
+                                                .name(main.getName())
+                                                .subOptions(
+                                                        main.getSubOptions() != null ?
+                                                                main.getSubOptions().stream().map(sub -> SubOptionDto.builder()
+                                                                        .name(sub.getName())
+                                                                        .price(sub.getPrice())
+                                                                        .build()).toList()
+                                                                : List.of()
+                                                )
+                                                .build()
+                                        ).toList()
+                                        : List.of()
+                        )
                         .build())
                 .toList();
+    }
+
+    public OptionAddResDto addOptionsToMenu(OptionAddReqDto reqDto) {
+        Menu menu = menuRepository.findById(UUID.fromString(reqDto.getMenuId()))
+                .orElseThrow(() -> new EntityNotFoundException("해당 메뉴를 찾을 수 없습니다."));
+
+        // 현재 메뉴에 이미 등록된 MainOption 이름 집합
+        Set<String> existingMainOptionNames = menu.getMainOptions().stream()
+                .map(MainOption::getName)
+                .collect(Collectors.toSet());
+
+        List<MainOption> mainOptionsToAdd = new ArrayList<>();
+
+        for (MainOptionDto mainDto : reqDto.getMainOptions()) {
+            String mainName = mainDto.getName();
+
+            if (existingMainOptionNames.contains(mainName)) {
+                throw new IllegalArgumentException("이미 등록된 메인 옵션 이름입니다: " + mainName);
+            }
+
+            MainOption mainOption = MainOption.builder()
+                    .menu(menu)
+                    .name(mainName)
+                    .build();
+
+            List<SubOption> subOptions = new ArrayList<>();
+            Set<String> subOptionNames = new HashSet<>();
+
+            if (mainDto.getSubOptions() != null) {
+                for (SubOptionDto subDto : mainDto.getSubOptions()) {
+                    String subName = subDto.getName();
+
+                    if (!subOptionNames.add(subName)) {
+                        throw new IllegalArgumentException("메인 옵션 '" + mainName + "'에 중복된 서브 옵션 이름이 있습니다: " + subName);
+                    }
+
+                    SubOption sub = SubOption.builder()
+                            .mainOption(mainOption)
+                            .name(subName)
+                            .price(subDto.getPrice())
+                            .build();
+
+                    subOptions.add(sub);
+                }
+            }
+
+            mainOption.setSubOptions(subOptions);
+            mainOptionsToAdd.add(mainOption);
+            existingMainOptionNames.add(mainName);
+        }
+
+        // 실제 저장
+        menu.getMainOptions().addAll(mainOptionsToAdd);
+
+        return OptionAddResDto.builder()
+                .menuId(menu.getId().toString())
+                .addedMainOptionCount(mainOptionsToAdd.size())
+                .build();
     }
 }
 

--- a/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddReqDto.java
@@ -1,0 +1,22 @@
+package com.beyond.jellyorder.domain.option.dto;
+
+import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OptionAddReqDto {
+
+    @NotBlank(message = "메뉴 ID(menuId)는 필수입니다.")
+    private String menuId;
+
+    @NotEmpty(message = "옵션 리스트는 비어있을 수 없습니다.")
+    private List<MainOptionDto> mainOptions;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddResDto.java
@@ -10,4 +10,5 @@ import lombok.*;
 public class OptionAddResDto {
     private String menuId;
     private int addedMainOptionCount;
+    private int addedSubOptionCount;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/dto/OptionAddResDto.java
@@ -1,0 +1,13 @@
+package com.beyond.jellyorder.domain.option.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OptionAddResDto {
+    private String menuId;
+    private int addedMainOptionCount;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/option/mainOption/domain/MainOption.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/mainOption/domain/MainOption.java
@@ -1,0 +1,28 @@
+package com.beyond.jellyorder.domain.option.mainOption.domain;
+
+
+import com.beyond.jellyorder.common.BaseIdEntity;
+import com.beyond.jellyorder.domain.menu.domain.Menu;
+import com.beyond.jellyorder.domain.option.subOption.domain.SubOption;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
+
+@Entity
+@Table(name = "main_option")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MainOption extends BaseIdEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "mainOption", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SubOption> subOptions;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/option/mainOption/dto/MainOptionDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/mainOption/dto/MainOptionDto.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.option.mainOption.dto;
+
+import com.beyond.jellyorder.domain.option.subOption.dto.SubOptionDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MainOptionDto {
+
+    @NotBlank(message = "메인 옵션 이름은 필수입니다.")
+    private String name;
+
+    // 서브 옵션은 없어도 될 수 있음
+    private List<SubOptionDto> subOptions;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/option/subOption/domain/SubOption.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/subOption/domain/SubOption.java
@@ -1,0 +1,31 @@
+package com.beyond.jellyorder.domain.option.subOption.domain;
+
+import com.beyond.jellyorder.common.BaseIdEntity;
+import com.beyond.jellyorder.domain.option.mainOption.domain.MainOption;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "sub_option")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubOption extends BaseIdEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_option_id", nullable = false)
+    private MainOption mainOption;
+
+    @NotBlank(message = "서브 옵션 이름은 필수입니다.")
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @NotNull(message = "서브 옵션 가격은 필수입니다.")
+    @Min(value = 0, message = "서브 옵션 가격은 0 이상이어야 합니다.")
+    @Column(name = "price", nullable = false)
+    private Integer price;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/option/subOption/dto/SubOptionDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/option/subOption/dto/SubOptionDto.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.option.subOption.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubOptionDto {
+
+    @NotBlank(message = "서브 옵션 이름은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "서브 옵션 가격은 필수입니다.")
+    @Min(value = 0, message = "서브 옵션 가격은 0 이상이어야 합니다.")
+    private Integer price;
+}


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴 옵션 추가 로직을 개선하여, 기존에는 메인 옵션명 중복만 검증하던 방식에서 메인 옵션명 + 서브 옵션명 조합 중복 검증이 가능하도록 변경하였습니다. 이로 인해 동일한 메인 옵션 내에서도 새로운 서브 옵션을 추가할 수 있으며, 요청 본문 내부의 중복 서브 옵션 입력도 방지됩니다. 또한 OptionAddResDto에 서브 옵션 생성 개수(addedSubOptionCount) 필드를 추가하여 응답 정보의 활용성을 높였습니다.

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuService.addOptionsToMenu 로직 변경
 - 기존의 메인 옵션명 단독 중복 검증 → 메인 옵션명 + 서브 옵션명 조합 중복 검증으로 변경
 - 동일 메인 옵션이 존재할 경우, 해당 메인 옵션 하위에 새로운 서브 옵션을 추가 가능하도록 수정
 - 요청 본문 내부에서 동일한 서브 옵션명이 반복되는 경우 예외 발생 처리
- OptionAddResDto에 addedSubOptionCount 필드 추가
 - 추가된 서브 옵션 개수를 응답에 포함시켜 클라이언트에서 통계 및 후처리에 활용 가능
- 중복 검증 로직 강화 및 데이터 무결성 보장

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #78 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 기존 API 스펙에는 변화가 없으나, 응답 DTO 구조(OptionAddResDto)에 필드가 추가되었으므로 해당 응답을 사용하는 클라이언트 측 로직 수정이 필요할 수 있습니다.
- 추후 메뉴 수정 API 구현 시, 동일한 방식의 컬렉션 동기화 로직을 적용하여 ID 유지한 상태로 옵션 수정이 가능하도록 할 예정입니다.
### 테스트 결과:
<img width="1996" height="988" alt="image" src="https://github.com/user-attachments/assets/7f93e3e7-b891-498b-b1cc-8ade324f70ad" />
<img width="2005" height="1151" alt="image" src="https://github.com/user-attachments/assets/c4ebd7b7-19a7-4de7-9452-fe5b5dfbeb38" />
<img width="2003" height="1072" alt="image" src="https://github.com/user-attachments/assets/d7eaf83b-f4c5-45b1-bccf-5acc7dd02daa" />

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.