### PR TITLE
[Feat] 메뉴 삭제 API 구현 (#86)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.menu.controller;
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
+import com.beyond.jellyorder.domain.menu.dto.MenuDeleteReqDto;
 import com.beyond.jellyorder.domain.menu.service.MenuService;
 import com.beyond.jellyorder.domain.option.dto.OptionAddReqDto;
 import com.beyond.jellyorder.domain.option.dto.OptionAddResDto;
@@ -57,4 +58,9 @@ public class MenuController {
         return ApiResponse.ok(resDto, "옵션이 정상적으로 추가되었습니다.");
     }
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteMenu(@RequestBody @Valid MenuDeleteReqDto reqDto) {
+        menuService.deleteMenuById(reqDto.getMenuId());
+        return ApiResponse.ok(null, "메뉴가 정상적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuDeleteReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuDeleteReqDto.java
@@ -1,0 +1,18 @@
+package com.beyond.jellyorder.domain.menu.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuDeleteReqDto {
+    @NotNull
+    private UUID menuId;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -345,5 +345,17 @@ public class MenuService {
                 .addedSubOptionCount(createdSubCount)
                 .build();
     }
+
+    public void deleteMenuById(UUID menuId) {
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 메뉴를 찾을 수 없습니다."));
+
+        // S3 이미지 삭제
+        if (menu.getImageUrl() != null) {
+            s3Manager.delete(menu.getImageUrl());
+        }
+
+        menuRepository.delete(menu); // cascade로 관련 옵션들 자동 삭제
+    }
 }
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴 ID를 기반으로 해당 메뉴와 연관된 옵션, 그리고 S3에 저장된 메뉴 이미지를 함께 삭제하는 메뉴 삭제 API를 구현하였습니다.

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuDeleteReqDto 생성
 - menuId 필드를 포함하고 NotNull 유효성 검증 적용
 - Lombok 어노테이션으로 보일러플레이트 코드 제거
- MenuService.deleteMenuById(UUID menuId) 구현
 - 전달받은 menuId로 메뉴 엔티티 조회 후 존재하지 않으면 EntityNotFoundException 발생
 - 메뉴 이미지 URL이 존재할 경우 S3에서 이미지 삭제
 - cascade와 orphanRemoval 설정을 활용해 연관된 옵션 엔티티 자동 삭제
- MenuController에 /menu/delete DELETE 엔드포인트 추가
 - 요청 DTO(MenuDeleteReqDto)로 메뉴 ID를 받아 서비스 로직 호출
 - 삭제 성공 시 200 OK와 "메뉴가 정상적으로 삭제되었습니다." 메시지 반환
- Postman을 통한 API 동작 검증 완료

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #86 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

### 테스트 결과:
<img width="1744" height="91" alt="image" src="https://github.com/user-attachments/assets/b1cb5032-8b0d-4a34-bb56-5d156e0bcf47" />
<img width="272" height="84" alt="image" src="https://github.com/user-attachments/assets/a8de344d-2905-452c-8bed-5208eec4544c" />
<img width="360" height="96" alt="image" src="https://github.com/user-attachments/assets/f19614a4-8316-4816-8e11-e7399cb15ea8" />
<img width="2010" height="487" alt="image" src="https://github.com/user-attachments/assets/b06f0ad5-d3f3-4086-aeb6-1c3e394bd64d" />
<img width="864" height="66" alt="image" src="https://github.com/user-attachments/assets/202648fe-9711-41c5-8a34-f14884467ed6" />
<img width="217" height="67" alt="image" src="https://github.com/user-attachments/assets/6bd128e6-a880-4cfc-bcb9-59595987e3f5" />
<img width="302" height="60" alt="image" src="https://github.com/user-attachments/assets/9e8b63bb-bfd4-4de7-8e27-4b8a32e418bf" />


<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.