### PR TITLE
[Feat] 식자재 불러오기 API 구현 (#88)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.ingredient.controller;
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateReqDto;
 import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateResDto;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientListResDto;
 import com.beyond.jellyorder.domain.ingredient.service.IngredientService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,11 @@ public class IngredientController {
 
         IngredientCreateResDto resDto = ingredientService.create(reqDto);
         return ApiResponse.created(resDto, resDto.getName() + " 식자재가 정상적으로 저장되었습니다.");
+    }
+
+    @GetMapping("/{storeId}/ingredients")
+    public ResponseEntity<?> getIngredients(@PathVariable String storeId) {
+        IngredientListResDto res = ingredientService.getIngredientsByStoreId(storeId);
+        return ResponseEntity.ok(ApiResponse.ok(res, "원재료 목록이 정상적으로 조회되었습니다."));
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientListResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientListResDto.java
@@ -1,0 +1,13 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IngredientListResDto {
+    private List<IngredientResDto> ingredients;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientResDto.java
@@ -1,0 +1,16 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import com.beyond.jellyorder.domain.ingredient.domain.IngredientStatus;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IngredientResDto {
+    private UUID id;
+    private String name;
+    private IngredientStatus status;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
@@ -5,6 +5,7 @@ import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,5 +20,5 @@ public interface IngredientRepository extends JpaRepository<Ingredient, UUID>, I
      */
     boolean existsByStoreIdAndName(String storeId, String name);  // TODO: UUID로 교체
     Optional<Ingredient> findByStoreIdAndName(String storeId, String name);
-
+    List<Ingredient> findAllByStoreId(String storeId);
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
storeId를 기반으로 해당 매장이 등록한 모든 식자재(Ingredient) 목록을 조회하는 API를 구현하였습니다.

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- IngredientRepository에 findAllByStoreId(String storeId) 메서드 추가하여 매장별 식자재 조회 기능 구현
- IngredientService에 getIngredientsByStoreId 메서드 추가
 - 추후 storeRepository.existsById를 활용해 storeId 유효성 검증 가능하도록 구조 설계
 - 조회 결과가 없는 경우 예외를 발생시키지 않고 빈 리스트를 담아 반환
 - Ingredient 엔티티를 IngredientResDto 리스트로 변환 후 IngredientListResDto에 담아 응답
- IngredientController에 GET /{storeId}/ingredients 엔드포인트 추가
 - 서비스 메서드 호출 후 조회된 결과를 ApiResponse 포맷으로 반환
 - 조회 성공 시 "원재료 목록이 정상적으로 조회되었습니다." 메시지와 함께 결과 전송

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #88 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 현재 storeId 유효성 검증 로직은 주석 처리 상태이며, 추후 Store 테이블과의 연관관계 설정 완료 시 활성화 예정
- 조회 결과가 없더라도 빈 리스트를 반환하므로, 프론트엔드에서 null 처리 없이 그대로 데이터 렌더링 가능
### 테스트 결과:
<img width="2005" height="694" alt="image" src="https://github.com/user-attachments/assets/08e6f604-cd1b-427b-b26b-a47a19771f26" />
<img width="2002" height="700" alt="image" src="https://github.com/user-attachments/assets/77680c7d-790f-4390-b1cf-60beaa4d3008" />

<br/>

### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.