### PR TITLE
[Feat] Store 이메일 검증 후 비밀번호 변경 (#92)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache' // 캐싱처리를 위한 의존성
 
+//	gmail 인증번호를 받기 위한 의존성 추가
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 
 
 }

--- a/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
@@ -36,8 +36,8 @@ public class SecurityConfig {
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(a -> a.requestMatchers(
                         "/store/create",
-                        "/store/doLogin",
-                        "/storetable/doLogin",
+                        "/store/do-login",
+                        "/storeTable/do-login",
                         "/store/refresh-at",
                         "/sse/**",
                         "/payment/**",

--- a/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable) // 비브라우저, 토큰로그인을 위한 csrf disable
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
-                .authorizeHttpRequests(a -> a.requestMatchers("/store/create", "/store/do-login", "/storetable/do-login", "/store/refresh-at", "/sse/**", "/request/**").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(a -> a.requestMatchers("/store/create", "/store/do-login", "/storetable/do-login", "/store/refresh-at", "/sse/**", "/request/**", "/password/**").permitAll().anyRequest().authenticated())
                 .exceptionHandling(e ->
                         e.authenticationEntryPoint(jwtAuthenticationHandler)
                                 .accessDeniedHandler(jwtAuthorizationHandler))

--- a/src/main/java/com/beyond/jellyorder/common/redis/PasswordResetRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/redis/PasswordResetRedisConfig.java
@@ -1,0 +1,33 @@
+package com.beyond.jellyorder.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+
+public class PasswordResetRedisConfig {
+    @Bean
+    public LettuceConnectionFactory passwordResetRedisCF(
+            @Value("${spring.redis.host}") String host,
+            @Value("${spring.redis.port}") int port
+    ) {
+        RedisStandaloneConfiguration passwordResetRedisConfig = new RedisStandaloneConfiguration(host, port);
+        passwordResetRedisConfig.setDatabase(3); // Redis index 3번 설정
+        return new LettuceConnectionFactory(passwordResetRedisConfig);
+    }
+
+    @Bean(name = "passwordResetRedisTemplate")
+    public RedisTemplate<String, String> passwordResetRedisTemplate(
+            LettuceConnectionFactory passwordResetRedisCF
+    ) {
+        RedisTemplate<String, String> t = new RedisTemplate<>();
+        t.setConnectionFactory(passwordResetRedisCF);
+        t.afterPropertiesSet();
+        return t;
+    }
+}
+

--- a/src/main/java/com/beyond/jellyorder/domain/store/controller/PasswordResetController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/controller/PasswordResetController.java
@@ -1,0 +1,44 @@
+package com.beyond.jellyorder.domain.store.controller;
+
+import com.beyond.jellyorder.domain.store.dto.PwResetCodeReqDTO;
+import com.beyond.jellyorder.domain.store.dto.PwResetCodeVerifyReqDTO;
+import com.beyond.jellyorder.domain.store.dto.PwResetUpdateReqDTO;
+import com.beyond.jellyorder.domain.store.service.PasswordResetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/password")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    /** 1) 인증코드 발송 */
+    @PostMapping("/send")
+    public ResponseEntity<?> sendCode(@RequestBody PwResetCodeReqDTO request) {
+        passwordResetService.sendVerificationCode(request.getEmail());
+        return ResponseEntity.ok("인증코드 발송 완료");
+    }
+
+    /** 2) 코드 검증 → ResetToken 발급 */
+    @PostMapping("/verify")
+    public ResponseEntity<String> verifyCode(@RequestBody PwResetCodeVerifyReqDTO request) {
+        String resetToken = passwordResetService.verifyCodeAndGetResetToken(
+                request.getEmail(),
+                request.getCode()
+        );
+        return ResponseEntity.ok(resetToken);
+    }
+
+    /** 3) 비밀번호 재설정 */
+    @PostMapping("/reset")
+    public ResponseEntity<String> resetPassword(@RequestBody PwResetUpdateReqDTO request) {
+        passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+        return ResponseEntity.ok("비밀번호 재설정 완료");
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/controller/PasswordResetController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/controller/PasswordResetController.java
@@ -1,9 +1,11 @@
 package com.beyond.jellyorder.domain.store.controller;
 
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.store.dto.PwResetCodeReqDTO;
 import com.beyond.jellyorder.domain.store.dto.PwResetCodeVerifyReqDTO;
 import com.beyond.jellyorder.domain.store.dto.PwResetUpdateReqDTO;
 import com.beyond.jellyorder.domain.store.service.PasswordResetService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,23 +24,23 @@ public class PasswordResetController {
     @PostMapping("/send")
     public ResponseEntity<?> sendCode(@RequestBody PwResetCodeReqDTO request) {
         passwordResetService.sendVerificationCode(request.getEmail());
-        return ResponseEntity.ok("인증코드 발송 완료");
+        return ApiResponse.ok("인증번호 발송 완료");
     }
 
     /** 2) 코드 검증 → ResetToken 발급 */
     @PostMapping("/verify")
-    public ResponseEntity<String> verifyCode(@RequestBody PwResetCodeVerifyReqDTO request) {
+    public ResponseEntity<?> verifyCode(@Valid @RequestBody PwResetCodeVerifyReqDTO request) {
         String resetToken = passwordResetService.verifyCodeAndGetResetToken(
                 request.getEmail(),
                 request.getCode()
         );
-        return ResponseEntity.ok(resetToken);
+        return ApiResponse.ok(resetToken, "인증번호 검증 완료");
     }
 
     /** 3) 비밀번호 재설정 */
     @PostMapping("/reset")
-    public ResponseEntity<String> resetPassword(@RequestBody PwResetUpdateReqDTO request) {
+    public ResponseEntity<?> resetPassword(@RequestBody PwResetUpdateReqDTO request) {
         passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
-        return ResponseEntity.ok("비밀번호 재설정 완료");
+        return ApiResponse.ok("비밀번호 재설정 완료");
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetCodeReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetCodeReqDTO.java
@@ -1,0 +1,16 @@
+package com.beyond.jellyorder.domain.store.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PwResetCodeReqDTO {
+    @NotBlank
+    @Email
+    private String email; // 인증코드를 받을 이메일
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetCodeVerifyReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetCodeVerifyReqDTO.java
@@ -1,0 +1,23 @@
+package com.beyond.jellyorder.domain.store.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PwResetCodeVerifyReqDTO {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 6)
+    @Pattern(regexp = "\\d{6}")
+    private String code; // 6자리 숫자
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetUpdateReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/dto/PwResetUpdateReqDTO.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.store.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 비밀번호 재설정: 새 비밀번호 변경 요청 */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PwResetUpdateReqDTO {
+
+    @NotBlank
+    private String token; // /password/verify에서 발급된 ResetToken
+
+    @NotBlank
+    @Size(min = 8) // 정책에 맞게 강화 가능(대문자/특수문자 등)
+    private String newPassword;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
@@ -37,4 +37,8 @@ public class Store extends BaseIdAndTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role = Role.STORE;
 
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.store.service;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
@@ -16,7 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
-@RequiredArgsConstructor
+@Slf4j
 public class PasswordResetService {
 
     private final JavaMailSender mailSender;
@@ -24,13 +25,19 @@ public class PasswordResetService {
     private final PasswordEncoder passwordEncoder;
 
     /** Redis DB=3 전용 템플릿(String, String) */
-    @Qualifier("passwordResetRedisTemplate")
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final String PREFIX_CODE  = "email:verify:";     // 인증코드 저장 키
     private static final String PREFIX_TOKEN = "password:reset:";    // 재설정 토큰 저장 키
     private static final long CODE_TTL_MINUTES  = 3;                 // 인증코드 유효시간(분)
     private static final long TOKEN_TTL_MINUTES = 10;                // 재설정 토큰 유효시간(분)
+
+    public PasswordResetService(JavaMailSender mailSender, StoreRepository storeRepository, PasswordEncoder passwordEncoder, @Qualifier("passwordResetRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.mailSender = mailSender;
+        this.storeRepository = storeRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.redisTemplate = redisTemplate;
+    }
 
     /** 1) 인증코드 발송 */
     public void sendVerificationCode(String email) {
@@ -40,6 +47,13 @@ public class PasswordResetService {
         }
 
         String code = String.format("%06d", new Random().nextInt(1_000_000));
+
+        // 📌 로그로 발신자/수신자/코드 확인
+        log.info("[비밀번호 재설정] 발신자: {}, 수신자: {}, 인증코드: {}",
+                "jellyorder.biz@gmail.com",  // yml의 spring.mail.username 값
+                email,
+                code
+        );
 
         // Redis 저장(기존 코드 덮어쓰기 + TTL)
         redisTemplate.opsForValue().set(PREFIX_CODE + email, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
@@ -1,0 +1,88 @@
+package com.beyond.jellyorder.domain.store.service;
+
+import com.beyond.jellyorder.domain.store.entity.Store;
+import com.beyond.jellyorder.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private final JavaMailSender mailSender;
+    private final StoreRepository storeRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /** Redis DB=3 전용 템플릿(String, String) */
+    @Qualifier("passwordResetRedisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREFIX_CODE  = "email:verify:";     // 인증코드 저장 키
+    private static final String PREFIX_TOKEN = "password:reset:";    // 재설정 토큰 저장 키
+    private static final long CODE_TTL_MINUTES  = 3;                 // 인증코드 유효시간(분)
+    private static final long TOKEN_TTL_MINUTES = 10;                // 재설정 토큰 유효시간(분)
+
+    /** 1) 인증코드 발송 */
+    public void sendVerificationCode(String email) {
+        Optional<Store> storeOpt = storeRepository.findByOwnerEmail(email);
+        if (storeOpt.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 이메일입니다.");
+        }
+
+        String code = String.format("%06d", new Random().nextInt(1_000_000));
+
+        // Redis 저장(기존 코드 덮어쓰기 + TTL)
+        redisTemplate.opsForValue().set(PREFIX_CODE + email, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);
+
+        // 메일 발송
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[멍멍냥냥] 비밀번호 재설정 인증코드");
+        message.setText("인증코드: " + code + "\n유효시간: " + CODE_TTL_MINUTES + "분");
+        mailSender.send(message);
+    }
+
+    /** 2) 코드 검증 → ResetToken 발급 */
+    public String verifyCodeAndGetResetToken(String email, String code) {
+        String savedCode = redisTemplate.opsForValue().get(PREFIX_CODE + email);
+        if (savedCode == null || !savedCode.equals(code)) {
+            throw new IllegalArgumentException("인증 코드가 유효하지 않습니다.");
+        }
+
+        // 사용한 코드 제거
+        redisTemplate.delete(PREFIX_CODE + email);
+
+        // ResetToken 생성 및 저장(10분)
+        String resetToken = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(PREFIX_TOKEN + resetToken, email, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+
+        return resetToken;
+    }
+
+    /** 3) 비밀번호 재설정 */
+    public void resetPassword(String token, String newPassword) {
+        String email = redisTemplate.opsForValue().get(PREFIX_TOKEN + token);
+        if (email == null) {
+            throw new IllegalArgumentException("재설정 토큰이 유효하지 않습니다.");
+        }
+
+        Store store = storeRepository.findByOwnerEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        store.updatePassword(passwordEncoder.encode(newPassword));
+        storeRepository.save(store);
+
+        // 사용 완료된 토큰 삭제
+        redisTemplate.delete(PREFIX_TOKEN + token);
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
@@ -58,11 +58,23 @@ public class PasswordResetService {
         // Redis 저장(기존 코드 덮어쓰기 + TTL)
         redisTemplate.opsForValue().set(PREFIX_CODE + email, code, CODE_TTL_MINUTES, TimeUnit.MINUTES);
 
+        String body = """
+        [JellyOrder] 비밀번호 재설정 안내
+        안녕하세요, JellyOrder를 이용해주셔서 감사합니다.
+        아래는 귀하께서 요청하신 '비밀번호 재설정' 인증코드입니다.
+        
+        아래 인증코드를 입력해 주세요.
+        인증코드: [  %s  ]%n%n
+        
+        유효시간: %d분
+        ※ 유효시간 내에 인증번호를 사용하여 '비밀번호 재설정'을 완료해 주세요.
+        """.formatted(code, CODE_TTL_MINUTES);
         // 메일 발송
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(email);
         message.setSubject("[JellyOrder] 비밀번호 재설정 인증코드");
-        message.setText("인증코드: " + code + "\n유효시간: " + CODE_TTL_MINUTES + "분");
+//        message.setText("인증코드: " + code + "\n유효시간: " + CODE_TTL_MINUTES + "분" + "\n유효시간 내로 인증번호를 사용하여 '비밀번호 재설정'을 해주세요.");
+        message.setText(body);
         mailSender.send(message);
     }
 

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
@@ -47,7 +47,7 @@ public class PasswordResetService {
         // 메일 발송
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(email);
-        message.setSubject("[멍멍냥냥] 비밀번호 재설정 인증코드");
+        message.setSubject("[JellyOrder] 비밀번호 재설정 인증코드");
         message.setText("인증코드: " + code + "\n유효시간: " + CODE_TTL_MINUTES + "분");
         mailSender.send(message);
     }

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/PasswordResetService.java
@@ -29,7 +29,7 @@ public class PasswordResetService {
 
     private static final String PREFIX_CODE  = "email:verify:";     // 인증코드 저장 키
     private static final String PREFIX_TOKEN = "password:reset:";    // 재설정 토큰 저장 키
-    private static final long CODE_TTL_MINUTES  = 3;                 // 인증코드 유효시간(분)
+    private static final long CODE_TTL_MINUTES  = 10;                 // 인증코드 유효시간(분)
     private static final long TOKEN_TTL_MINUTES = 10;                // 재설정 토큰 유효시간(분)
 
     public PasswordResetService(JavaMailSender mailSender, StoreRepository storeRepository, PasswordEncoder passwordEncoder, @Qualifier("passwordResetRedisTemplate") RedisTemplate<String, String> redisTemplate) {
@@ -41,14 +41,14 @@ public class PasswordResetService {
 
     /** 1) 인증코드 발송 */
     public void sendVerificationCode(String email) {
-        Optional<Store> storeOpt = storeRepository.findByOwnerEmail(email);
-        if (storeOpt.isEmpty()) {
+        Optional<Store> optionalStore = storeRepository.findByOwnerEmail(email);
+        if (optionalStore.isEmpty()) {
             throw new IllegalArgumentException("존재하지 않는 이메일입니다.");
         }
 
         String code = String.format("%06d", new Random().nextInt(1_000_000));
 
-        // 📌 로그로 발신자/수신자/코드 확인
+        // 로그로 발신자/수신자/코드 확인
         log.info("[비밀번호 재설정] 발신자: {}, 수신자: {}, 인증코드: {}",
                 "jellyorder.biz@gmail.com",  // yml의 spring.mail.username 값
                 email,

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
@@ -65,9 +65,9 @@ public class StoreService {
     /* Store 로그인 Service*/
     public Store doLogin(StoreLoginReqDTO storeLoginReqDTO) {
         Store store = storeRepository.findByLoginId(storeLoginReqDTO.getLoginId())
-                .orElseThrow(() -> new EntityNotFoundException("아이디!! 또는 비밀번호가 일치하지 않습니다.")) ; /* "로그인 정보가 일치하지 않습니다", 통일 예정 */
+                .orElseThrow(() -> new EntityNotFoundException("로그인 정보가 일치하지 않습니다.")) ;
         if (!passwordEncoder.matches(storeLoginReqDTO.getPassword(), store.getPassword())){
-            throw new IllegalArgumentException("아이디 또는 비밀번호!!가 일치하지 않습니다."); /* "로그인 정보가 일치하지 않습니다", 통일 예정 */
+            throw new IllegalArgumentException("로그인 정보가 일치하지 않습니다.");
         }
         return store;
 

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/service/StoreTableService.java
@@ -113,13 +113,13 @@ public class StoreTableService {
 
     public StoreTable doLogin(StoreTableLoginReqDTO storeTableLoginReqDTO) {
         Store store = storeRepository.findByLoginId(storeTableLoginReqDTO.getLoginId())
-                .orElseThrow(() -> new EntityNotFoundException("아이디!! 또는 비밀번호가 틀렸습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("로그인 정보가 일치하지 않습니다."));
 
         StoreTable storeTable = storeTableRepository.findByStoreAndName(store, storeTableLoginReqDTO.getName())
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 테이블입니다."));
 
         if (!passwordEncoder.matches(storeTableLoginReqDTO.getPassword(), store.getPassword())) {
-            throw new IllegalArgumentException("아이디 또는 비밀번호!!가 틀렸습니다.");
+            throw new IllegalArgumentException("로그인 정보가 일치하지 않습니다.");
         }
 
         return storeTable;


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
비밀번호 재설정 기능 도입: 인증코드 발송 → 코드 검증(ResetToken 발급) → 비밀번호 재설정 전 흐름 구현
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- Controller (PasswordResetController)
POST /password/send — PwResetCodeReqDTO, 인증코드 발송
POST /password/verify — PwResetCodeVerifyReqDTO, resetToken 반환
POST /password/reset — PwResetUpdateReqDTO, 비밀번호 변경

- Service (PasswordResetService)
6자리 코드 생성·저장: email:verify:<email> (TTL 10분)
검증 후 토큰 발급·저장: password:reset:<token> = email (TTL 10분), 사용 즉시 삭제
PasswordEncoder로 해시 후 저장, (권장) @Transactional

- Redis
passwordResetRedisTemplate(String/String, DB=3) 사용
생성자 주입에 @Qualifier("passwordResetRedisTemplate") 명시

- Security
requestMatchers("/password/**").permitAll()

- 메일
발신: spring.mail.username(예: jellyorder.biz@gmail.com)
로그에 수신자/코드 출력, (선택) MimeMessageHelper로 HTML 강조

- 테스트
순서: /password/send → /password/verify → /password/reset
성공 시 DB 비밀번호 변경·토큰 키 삭제 확인

- RDB, Redis 확인 완료
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  

<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
<img width="478" height="544" alt="image" src="https://github.com/user-attachments/assets/d6ee03bd-277b-4df8-ab73-020d03b6f138" />

<img width="740" height="580" alt="image" src="https://github.com/user-attachments/assets/641a6004-47d0-479c-89d6-422903b29318" />

<img width="667" height="538" alt="image" src="https://github.com/user-attachments/assets/194aacd2-1d98-451a-9c1f-6b08cc142484" />

<img width="631" height="759" alt="image" src="https://github.com/user-attachments/assets/c96ce4a3-895c-4bc6-a071-e18280c65cd0" />

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.