### PR TITLE
[Feat] 식자재 삭제 API 구현 (#90)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/controller/IngredientController.java
@@ -1,9 +1,7 @@
 package com.beyond.jellyorder.domain.ingredient.controller;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
-import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateReqDto;
-import com.beyond.jellyorder.domain.ingredient.dto.IngredientCreateResDto;
-import com.beyond.jellyorder.domain.ingredient.dto.IngredientListResDto;
+import com.beyond.jellyorder.domain.ingredient.dto.*;
 import com.beyond.jellyorder.domain.ingredient.service.IngredientService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -35,5 +33,11 @@ public class IngredientController {
     public ResponseEntity<?> getIngredients(@PathVariable String storeId) {
         IngredientListResDto res = ingredientService.getIngredientsByStoreId(storeId);
         return ResponseEntity.ok(ApiResponse.ok(res, "원재료 목록이 정상적으로 조회되었습니다."));
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteIngredient(@RequestBody @Valid IngredientDeleteReqDto reqDto) {
+        IngredientDeleteResDto res = ingredientService.delete(reqDto);
+        return ResponseEntity.ok(ApiResponse.ok(res, "식자재가 정상적으로 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/domain/Ingredient.java
@@ -1,8 +1,12 @@
 package com.beyond.jellyorder.domain.ingredient.domain;
 
 import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
+import com.beyond.jellyorder.domain.menu.domain.MenuIngredient;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 재료(Ingredient) 엔티티.
@@ -47,5 +51,9 @@ public class Ingredient extends BaseIdAndTimeEntity {
     @Column(length = 10, nullable = false)
     private IngredientStatus status = IngredientStatus.SUFFICIENT;
 
-    // 추후: 재고 상태 변경 메서드 등 도메인 로직 추가 가능 (e.g., updateStatus(IngredientStatus.INSUFFICIENT))
+    @OneToMany(mappedBy = "ingredient",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @ToString.Exclude
+    private List<MenuIngredient> menuIngredients = new ArrayList<>();
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDeleteReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDeleteReqDto.java
@@ -1,0 +1,15 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class IngredientDeleteReqDto {
+    @NotBlank
+    private String storeId;     // 소속 검증용
+    @NotNull
+    private UUID ingredientId;  // 삭제 대상
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDeleteResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDeleteResDto.java
@@ -1,0 +1,18 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import lombok.*;
+import java.util.List;
+import java.util.UUID;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class IngredientDeleteResDto {
+    private UUID ingredientId;
+    private String ingredientName;
+    private List<AffectedMenuDto> affectedMenus;
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class AffectedMenuDto {
+        private UUID id;
+        private String name;
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientDto.java
@@ -1,0 +1,15 @@
+package com.beyond.jellyorder.domain.ingredient.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IngredientDto {
+    private UUID id;
+    private String name;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/repository/IngredientRepository.java
@@ -1,8 +1,9 @@
 package com.beyond.jellyorder.domain.ingredient.repository;
 
-import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +22,17 @@ public interface IngredientRepository extends JpaRepository<Ingredient, UUID>, I
     boolean existsByStoreIdAndName(String storeId, String name);  // TODO: UUID로 교체
     Optional<Ingredient> findByStoreIdAndName(String storeId, String name);
     List<Ingredient> findAllByStoreId(String storeId);
+
+    interface AffectedMenu {
+        String getId();   // BIN_TO_UUID 결과를 받음
+        String getName();
+    }
+
+    @Query(value = """
+        SELECT BIN_TO_UUID(m.id) AS id, m.name AS name
+        FROM menu m
+        JOIN menu_ingredient mi ON mi.menu_id = m.id
+        WHERE mi.ingredient_id = :ingredientId
+        """, nativeQuery = true)
+    List<AffectedMenu> findAffectedMenus(@Param("ingredientId") UUID ingredientId);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -4,6 +4,7 @@ import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateReqDto;
 import com.beyond.jellyorder.domain.menu.dto.MenuCreateResDto;
 import com.beyond.jellyorder.domain.menu.dto.MenuDeleteReqDto;
+import com.beyond.jellyorder.domain.menu.dto.MenuListResDto;
 import com.beyond.jellyorder.domain.menu.service.MenuService;
 import com.beyond.jellyorder.domain.option.dto.OptionAddReqDto;
 import com.beyond.jellyorder.domain.option.dto.OptionAddResDto;
@@ -46,7 +47,7 @@ public class MenuController {
 
     @GetMapping("/store/{storeId}")
     public ResponseEntity<?> getMenusByStoreId(@PathVariable String storeId) {
-        List<MenuCreateResDto> resDtos = menuService.getMenusByStoreId(storeId);
+        List<MenuListResDto> resDtos = menuService.getMenusByStoreId(storeId);
         return ApiResponse.ok(resDtos, "메뉴 목록이 정상적으로 조회되었습니다.");
     }
 

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
@@ -6,6 +6,7 @@ import com.beyond.jellyorder.domain.option.mainOption.domain.MainOption;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -46,4 +47,10 @@ public class Menu extends BaseIdAndTimeEntity {
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MainOption> mainOptions;
+
+    @OneToMany(mappedBy = "menu",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @ToString.Exclude
+    private List<MenuIngredient> menuIngredients = new ArrayList<>();
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredient.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredient.java
@@ -6,24 +6,23 @@ import lombok.*;
 
 @Entity
 @Table(name = "menu_ingredient")
-@Getter
-@Setter
+@Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MenuIngredient {
 
     @EmbeddedId
-    private MenuIngredientId id;
+    @Builder.Default
+    private MenuIngredientId id = new MenuIngredientId();
 
-    // FK 관계 제거: 주석 처리
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @MapsId("menuId")
-    // @JoinColumn(name = "menu_id", referencedColumnName = "id", insertable = false, updatable = false)
-    // private Menu menu;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("menuId")
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
 
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @MapsId("ingredientId")
-    // @JoinColumn(name = "ingredient_id", referencedColumnName = "id", insertable = false, updatable = false)
-    // private Ingredient ingredient;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("ingredientId")
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredientId.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/MenuIngredientId.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import lombok.*;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
@@ -20,5 +21,16 @@ public class MenuIngredientId implements Serializable {
     @Column(name = "ingredient_id", columnDefinition = "BINARY(16)")
     private UUID ingredientId;
 
-    // equals, hashCode 반드시 구현해야 함
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true; // 같은 객체면 true
+        if (!(o instanceof MenuIngredientId that)) return false; // 타입이 다르면 false
+        return Objects.equals(menuId, that.menuId) &&
+                Objects.equals(ingredientId, that.ingredientId); // 두 필드 값이 같으면 true
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(menuId, ingredientId);
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuListResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuListResDto.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.menu.dto;
+
+import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuListResDto {
+    private UUID id;
+    private String name;
+    private Integer price;
+    private String imageUrl;
+    private List<MainOptionDto> mainOptions;
+    private List<String> ingredients;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuListResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuListResDto.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.domain.menu.dto;
 
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientDto;
 import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
 import lombok.*;
 
@@ -17,5 +18,5 @@ public class MenuListResDto {
     private Integer price;
     private String imageUrl;
     private List<MainOptionDto> mainOptions;
-    private List<String> ingredients;
+    private List<IngredientDto> ingredients;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -4,6 +4,7 @@ import com.beyond.jellyorder.common.s3.S3Manager;
 import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.category.repository.CategoryRepository;
 import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
+import com.beyond.jellyorder.domain.ingredient.dto.IngredientDto;
 import com.beyond.jellyorder.domain.ingredient.repository.IngredientRepository;
 import com.beyond.jellyorder.domain.menu.domain.Menu;
 import com.beyond.jellyorder.domain.menu.domain.MenuIngredient;
@@ -256,32 +257,44 @@ public class MenuService {
                         .price(menu.getPrice())
                         .imageUrl(menu.getImageUrl())
                         .mainOptions(
-                                menu.getMainOptions() != null ?
-                                        menu.getMainOptions().stream().map(main -> MainOptionDto.builder()
+                                menu.getMainOptions() != null
+                                        ? menu.getMainOptions().stream()
+                                        .map(main -> MainOptionDto.builder()
                                                 .name(main.getName())
                                                 .subOptions(
-                                                        main.getSubOptions() != null ?
-                                                                main.getSubOptions().stream().map(sub -> SubOptionDto.builder()
+                                                        main.getSubOptions() != null
+                                                                ? main.getSubOptions().stream()
+                                                                .map(sub -> SubOptionDto.builder()
                                                                         .name(sub.getName())
                                                                         .price(sub.getPrice())
-                                                                        .build()).toList()
+                                                                        .build())
+                                                                .toList()
                                                                 : List.of()
                                                 )
-                                                .build()
-                                        ).toList()
+                                                .build())
+                                        .toList()
                                         : List.of()
                         )
                         .ingredients(
-                                menu.getMenuIngredients() != null ?
-                                        menu.getMenuIngredients().stream()
-                                                .map(mi -> mi.getIngredient().getName())
-                                                .toList()
+                                menu.getMenuIngredients() != null
+                                        ? menu.getMenuIngredients().stream()
+                                        .map(mi -> mi.getIngredient())
+                                        // (선택) 같은 재료 중복 제거
+                                        .collect(java.util.stream.Collectors.toMap(
+                                                ing -> ing.getId(), // key
+                                                ing -> IngredientDto.builder()
+                                                        .id(ing.getId())
+                                                        .name(ing.getName())
+                                                        .build(),
+                                                (a, b) -> a
+                                        ))
+                                        .values().stream().toList()
                                         : List.of()
                         )
                         .build())
                 .toList();
     }
-
+    
     public OptionAddResDto addOptionsToMenu(OptionAddReqDto reqDto) {
         Menu menu = menuRepository.findById(UUID.fromString(reqDto.getMenuId()))
                 .orElseThrow(() -> new EntityNotFoundException("해당 메뉴를 찾을 수 없습니다."));


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴와 식자재 간 연관 매핑 구조를 개선하고, 식자재 삭제 API를 구현했습니다. 또한 메뉴 목록 조회 시 식자재 정보를 함께 반환하도록 DTO를 변경했습니다.

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuIngredientId에 equals/hashCode를 구현하고, MenuIngredient에 EmbeddedId 및 @MapsId를 적용해 복합키 매핑 안정성을 확보했습니다.
- Ingredient와 Menu 엔티티에 OneToMany(cascade = ALL, orphanRemoval = true)를 적용해 연관 엔티티 삭제 시 일관된 처리 가능하도록 수정했습니다.
- 식자재 삭제 요청/응답 DTO(IngredientDeleteReqDto, IngredientDeleteResDto)를 추가하고, 영향 메뉴를 조회하는 네이티브 쿼리 메서드를 IngredientRepository에 구현했습니다.
- 메뉴 조회 응답 DTO를 MenuListResDto로 교체하여 ingredients 필드 포함, 컨트롤러의 반환 타입을 변경했습니다.
- MenuService#create 로직 순서를 조정해 메뉴 저장 후 옵션/식자재를 매핑하도록 수정했습니다.

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #90 

<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
### 테스트 결과:
<img width="1470" height="1041" alt="image" src="https://github.com/user-attachments/assets/475d93df-c2f1-429f-bacd-228af2550495" />
<img width="1479" height="1130" alt="image" src="https://github.com/user-attachments/assets/2f199202-aa27-4c2c-8342-94fc3e7ba18a" />
<img width="1484" height="956" alt="image" src="https://github.com/user-attachments/assets/888746fa-1767-484f-9694-85041a89baf2" />
<img width="1481" height="927" alt="image" src="https://github.com/user-attachments/assets/ffd064d9-0df4-498d-9d69-0b18b5a2e66d" />
<img width="1482" height="1034" alt="image" src="https://github.com/user-attachments/assets/0bb85b51-d404-45c8-8ee9-b687345dfe49" />


<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.