### PR TITLE
[Feat] 주문 전송 API 구현 (#100)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/auth/SecurityConfig.java
@@ -36,11 +36,17 @@ public class SecurityConfig {
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(a -> a.requestMatchers(
                         "/store/create",
-                        "/store/doLogin",
-                        "/storetable/doLogin",
+                        "/store/do-login",
+                        "/storetable/do-login",
                         "/store/refresh-at",
                         "/sse/**",
                         "/payment/**",
+                        "/menu/**",
+                        "/orders/**",
+                        "/category/**",
+                        "/ingredient/**",
+                        "/store-table/**",
+                        "/zone/**",
                         "/v3/api-docs/**",  // swagger 추가
                         "/swagger-ui/**",   // swagger 추가
                         "/swagger-ui.html"  // swagger 추가

--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.beyond.jellyorder.domain.order.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.order.dto.UnitOrderCreateReqDto;
+import com.beyond.jellyorder.domain.order.dto.UnitOrderResDto;
+import com.beyond.jellyorder.domain.order.service.OrderService;
+import com.beyond.jellyorder.domain.storetable.service.StoreTableService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+@PreAuthorize("hasRole('STORE')")
+public class OrderController {
+
+    private final OrderService unitOrderService;
+    private final StoreTableService storeTableService;
+
+    /** 단위주문 생성 */
+    @PostMapping("/unit/create")
+    public ResponseEntity<?> createUnit(@RequestBody @Valid UnitOrderCreateReqDto reqDTO) {
+        UnitOrderResDto resDTO = unitOrderService.createUnit(reqDTO);
+
+        return ApiResponse.created(resDTO, "단위주문이 생성되었습니다.");
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderCreateReqDto.java
@@ -1,0 +1,18 @@
+package com.beyond.jellyorder.domain.order.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.query.Order;
+
+import java.util.List;
+import java.util.UUID;
+
+/** 단위 주문 요청 DTO */
+@Getter
+@Setter
+@NoArgsConstructor
+public class UnitOrderCreateReqDto {
+    private UUID storeTableId;
+    List<UnitOrderMenuReqDto> menus;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderMenuReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderMenuReqDto.java
@@ -1,0 +1,16 @@
+package com.beyond.jellyorder.domain.order.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/** 단위 주문 메뉴 DTO */
+@Getter
+@Setter
+@NoArgsConstructor
+public class UnitOrderMenuReqDto {
+    private UUID menuId;
+    private Integer quantity;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/UnitOrderResDto.java
@@ -1,0 +1,17 @@
+package com.beyond.jellyorder.domain.order.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+/** 단위 주문 응답 DTO */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UnitOrderResDto {
+    private UUID totalOrderId;
+    private UUID unitOrderId;
+    private Integer unitPrice;  // 이번 전송 금액 합
+    private Integer unitCount;  // 이번 전송 수량 합
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
@@ -48,4 +48,10 @@ public class TotalOrder extends BaseIdEntity {
     protected void onCreate() {
         this.orderedAt = LocalDateTime.now();
     }
+
+    // 단위주문 총 금액
+    public void addUnitTotal(int price, int count) {
+        this.totalPrice += price;
+        this.count += count;
+    }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
@@ -61,5 +61,10 @@ public class UnitOrder extends BaseIdEntity {
         };
     }
 
+    // 단위주문 총 수량
+    public void setUnitCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
 }
 

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderService.java
@@ -1,0 +1,102 @@
+package com.beyond.jellyorder.domain.order.service;
+
+import com.beyond.jellyorder.domain.menu.domain.Menu;
+import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
+import com.beyond.jellyorder.domain.order.dto.UnitOrderCreateReqDto;
+import com.beyond.jellyorder.domain.order.dto.UnitOrderMenuReqDto;
+import com.beyond.jellyorder.domain.order.dto.UnitOrderResDto;
+import com.beyond.jellyorder.domain.order.entity.OrderMenu;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.entity.TotalOrder;
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import com.beyond.jellyorder.domain.order.repository.OrderMenuRepository;
+import com.beyond.jellyorder.domain.order.repository.TotalOrderRepository;
+import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
+import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
+import com.beyond.jellyorder.domain.storetable.repository.StoreTableRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final UnitOrderRepository unitOrderRepository;
+    private final OrderMenuRepository orderMenuRepository;
+    private final TotalOrderRepository totalOrderRepository;
+    private final StoreTableRepository storeTableRepository;
+    private final MenuRepository menuRepository;
+    // pub/sub 기능 위해 Redis 필요
+
+    /**
+     * 단위주문 생성
+     * 해당 테이블의 최신 전체주문을 찾고, 종료되지 않았다면 재사용
+     * 없거나 이미 종료(endedAt != null)면 새 전체주문 생성
+     * 요청 내 각 메뉴 수량 >= 1
+     * 총 금액/수량 집계 후 TotalOrder에 누적
+     */
+    public UnitOrderResDto createUnit(UnitOrderCreateReqDto dto) {
+        /* 테이블 조회 */
+        StoreTable storeTable = storeTableRepository.findById(dto.getStoreTableId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 매장의 테이블이 없습니다."));
+
+        /* 종료되지 않은 주문 확보 */
+        TotalOrder totalOrder = totalOrderRepository.findTopByStoreTableOrderByOrderedAtDesc(storeTable)
+                .filter(to -> to.getEndedAt() == null)  // 종료되지 않은 주문만 재사용
+                .orElseGet(() -> totalOrderRepository.save(
+                        TotalOrder.builder()
+                                .storeTable(storeTable)
+                                .totalPrice(0)  // 새로 시작하는 전체 주문의 초기값
+                                .count(0)       // 새로 시작하는 전체 주문의 초기값
+                                .build()
+                ));
+
+        /* 단위주문 전송 시 합계/수량 */
+        int unitPrice = 0;      // 단위주문의 합계 금액
+        int unitCount = 0;      // 단위주문의 총 수량
+
+        /* 단위주문 생성 & 저장 */
+        UnitOrder unitOrder = UnitOrder.builder()
+                .totalOrder(totalOrder)
+                .status(OrderStatus.ACCEPT) // 전송 직후 상태는 ACCEPT
+                .totalCount(0)
+                .build();
+        unitOrderRepository.save(unitOrder);
+
+        /* OrderMenu 저장 */
+        for (UnitOrderMenuReqDto menuReqDto : dto.getMenus()) {
+            if (menuReqDto.getQuantity() <= 0) {
+                throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
+            }
+            Menu menu = menuRepository.findById(menuReqDto.getMenuId())
+                    .orElseThrow(() -> new EntityNotFoundException("해당 메뉴가 존재하지 않습니다."));
+
+            /* 단위주문 금액, 수량 계산 */
+            Integer menuPrice = menu.getPrice() * menuReqDto.getQuantity();
+            unitPrice += menuPrice;
+            unitCount += menuReqDto.getQuantity();
+
+
+            OrderMenu orderMenu = OrderMenu.builder()
+                    .unitOrder(unitOrder)
+                    .menu(menu)
+                    .quantity(menuReqDto.getQuantity())
+                    .build();
+            orderMenuRepository.save(orderMenu);
+        }
+
+        /* 집계 반영 */
+        unitOrder.setUnitCount(unitCount);
+        totalOrder.addUnitTotal(unitPrice, unitCount);
+
+        return UnitOrderResDto.builder()
+                        .totalOrderId(totalOrder.getId())
+                        .unitOrderId(unitOrder.getId())
+                        .unitPrice(unitPrice)
+                        .unitCount(unitCount)
+                        .build();
+    }
+}


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
주문 전송 API 구현
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
 - 해당 storeTableId와 menuId로 단위주문 생성
 - 해당 테이블의 최신 전체주문을 찾고 점주가 clear하지 않은 테이블인 경우, 해당 전체주문 내역(영수증)을 재사용
 - 점주가 clear한 테이블인 경우 새 전체주문 생성
 - 요청 내 각 메뉴 수량은 1 이상이도록 설정
 - 총 금액과 수량 집계 후 TotalOrder에 누적
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
#100 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
 - WebSocket, Redis 구현하여 실시간 주문 업데이트 되도록 구현 필요
 - order_number, cancelled_at, completed_at도 위의 사항 구현 이후 데이터 생성될 예정
<br/>


### 💻 테스트 화면
##
 - 1번 테이블에서 단위주문 생성
<img width="1373" height="740" alt="스크린샷 2025-08-12 180045" src="https://github.com/user-attachments/assets/353c17f4-d3c1-4e95-8f45-ade3188819a5" />
 - 1번 테이블에서 단위주문 후 RDB의 단위주문 테이블
<img width="1249" height="316" alt="스크린샷 2025-08-12 180127" src="https://github.com/user-attachments/assets/66df320e-0974-43df-9f80-b776851cf776" />
 - 1번 테이블에서 단위주문 후 RDB의 전체주문 테이블
<img width="1253" height="283" alt="스크린샷 2025-08-12 180113" src="https://github.com/user-attachments/assets/1b321f94-9399-4ea7-8548-2b83f091d8a5" />
<br/>


##
 - 2번 테이블에서 단위주문 생성
<img width="1364" height="749" alt="image" src="https://github.com/user-attachments/assets/fa31c442-4698-4efb-bf7b-b114874dc50a" />
 - 2번 테이블에서 단위주문 후 RDB의 단위주문 테이블
<img width="1254" height="327" alt="image" src="https://github.com/user-attachments/assets/215b52a2-c33b-4715-b878-722ea2eac5bd" />
 - 2번 테이블에서 단위주문 후 RDB의 전체주문 테이블
<img width="1252" height="333" alt="image" src="https://github.com/user-attachments/assets/119f587d-a39c-4e6a-8ce0-637b617b2ed4" />
<br/>


##
 - 1번 테이블에서 단위주문 추가생성
 <img width="1366" height="729" alt="image" src="https://github.com/user-attachments/assets/047fabd7-7e77-44e5-b22a-bb5848db20e9" />
 - 1번 테이블에서 단위주문 추가생성 후 RDB의 단위주문 테이블
<img width="1252" height="339" alt="image" src="https://github.com/user-attachments/assets/17c732fd-011b-4fb5-9dfb-754670bcee45" />
 - 1번 테이블에서 단위주문 추가생성 후 RDB의 전체주문 테이블
<img width="1243" height="327" alt="image" src="https://github.com/user-attachments/assets/f653c1ef-6aa9-4f60-b1dc-15437f431b3a" />




<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.