### PR TITLE
[Feat] 주문 현황 리스트 조회 API 구현 (#115)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
@@ -1,0 +1,57 @@
+package com.beyond.jellyorder.domain.order.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.service.OrderStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order-status")
+@PreAuthorize("hasRole('STORE')")
+public class OrderStatusController {
+
+    private final OrderStatusService orderStatusService;
+
+    @GetMapping("/{orderStatus}")
+    public ResponseEntity<?> getOrderListInOrderStatus(
+            @PathVariable OrderStatus orderStatus,
+            @PageableDefault(size = 20, sort = "localtime", direction = Sort.Direction.ASC)Pageable pageable
+            ) {
+        Page<OrderStatusResDTO> resDTOs = orderStatusService.getOrderListInOrderStatus(orderStatus, pageable);
+        return ApiResponse.ok(resDTOs);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
@@ -29,7 +29,7 @@ public class OrderStatusController {
     @GetMapping("/{orderStatus}")
     public ResponseEntity<?> getOrderListInOrderStatus(
             @PathVariable OrderStatus orderStatus,
-            @PageableDefault(size = 20, sort = "localtime", direction = Sort.Direction.ASC)Pageable pageable
+            @PageableDefault(size = 20, sort = "acceptedAt", direction = Sort.Direction.ASC)Pageable pageable
             ) {
         Page<OrderStatusResDTO> resDTOs = orderStatusService.getOrderListInOrderStatus(orderStatus, pageable);
         return ApiResponse.ok(resDTOs);

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenu.java
@@ -1,0 +1,29 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.OrderMenu;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusMenu {
+    private String menuName;
+    private Integer menuQuantity;
+    private List<OrderStatusMenuOption> optionList;
+
+    public static OrderStatusMenu from(OrderMenu orderMenu) {
+        return OrderStatusMenu.builder()
+                .menuName(orderMenu.getMenu().getName())
+                .menuQuantity(orderMenu.getQuantity())
+                .optionList(orderMenu.getOrderMenuOptionList().stream()
+                        .map(OrderStatusMenuOption::from).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenuOption.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenuOption.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.OrderMenuOption;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusMenuOption {
+    private String optionName;
+
+    public static OrderStatusMenuOption from(OrderMenuOption option) {
+        return OrderStatusMenuOption.builder()
+                .optionName(option.getSubOption().getName())
+                .build();
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusResDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusResDTO.java
@@ -1,0 +1,34 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusResDTO {
+    private UUID unitOrderId;
+    private Integer orderNumber;
+    private String storeTableName;
+    private LocalTime localTime;
+    private List<OrderStatusMenu> orderMenuList;
+
+    public static OrderStatusResDTO from(UnitOrder unitOrder) {
+        return OrderStatusResDTO.builder()
+                .unitOrderId(unitOrder.getId())
+                .orderNumber(unitOrder.getOrderNumber())
+                .storeTableName(unitOrder.getTotalOrder().getStoreTable().getName()) // join이 너무 많음.
+                .localTime(unitOrder.getRelevantTime())
+                .orderMenuList(unitOrder.getOrderMenus().stream().map(OrderStatusMenu::from).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
@@ -54,7 +54,7 @@ public class UnitOrder extends BaseIdEntity {
 
     // 주문 상태의 따라 시간 값 추출 메서드
     public LocalTime getRelevantTime() {
-        return switch (status) {
+        return switch (this.status) {
             case ACCEPT   -> LocalTime.from(getAcceptedAt());
             case COMPLETE -> LocalTime.from(getCompletedAt());
             case CANCEL   -> LocalTime.from(getCancelledAt());

--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
@@ -4,8 +4,12 @@ import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,4 +19,22 @@ public interface UnitOrderRepository extends JpaRepository<UnitOrder, UUID> {
     List<UnitOrder> findAllByTotalOrderIdAndStatusNot(UUID totalOrderId, OrderStatus status);
 
     Page<UnitOrder> findByStatus(OrderStatus orderStatus, Pageable pageable);
+
+    // 상태 + 매장 + 시간 구간 + 페이징
+    @Query("""
+        select u
+        from UnitOrder u
+        join u.totalOrder t
+        join t.storeTable st
+        join st.store s
+        where s.id = :storeId
+          and u.status = :status
+          and u.acceptedAt >= :startAt
+        """)
+    Page<UnitOrder> findPageByStoreAndStatusWithin(
+            @Param("storeId") UUID storeId,
+            @Param("status") OrderStatus status,
+            @Param("startAt") LocalDateTime startAt,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
@@ -2,6 +2,8 @@ package com.beyond.jellyorder.domain.order.repository;
 
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +14,5 @@ public interface UnitOrderRepository extends JpaRepository<UnitOrder, UUID> {
     // 해당 인자값의 status가 아닌 totalOrder에 속한 unitOrder리스트 추출 메서드.
     List<UnitOrder> findAllByTotalOrderIdAndStatusNot(UUID totalOrderId, OrderStatus status);
 
+    Page<UnitOrder> findByStatus(OrderStatus orderStatus, Pageable pageable);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -1,0 +1,28 @@
+package com.beyond.jellyorder.domain.order.service;
+
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderStatusService {
+
+    private final UnitOrderRepository unitOrderRepository;
+
+    @Transactional(readOnly = true)
+    public Page<OrderStatusResDTO> getOrderListInOrderStatus(OrderStatus orderStatus, Pageable pageable) {
+        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findByStatus(orderStatus, pageable);
+
+        return unitOrderPageList.map(OrderStatusResDTO::from);
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -1,9 +1,13 @@
 package com.beyond.jellyorder.domain.order.service;
 
+import com.beyond.jellyorder.common.auth.StoreJwtClaimUtil;
 import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
 import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
+import com.beyond.jellyorder.domain.store.entity.Store;
+import com.beyond.jellyorder.domain.store.repository.StoreRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -18,10 +23,24 @@ import java.util.List;
 public class OrderStatusService {
 
     private final UnitOrderRepository unitOrderRepository;
+    private final StoreJwtClaimUtil storeJwtClaimUtil;
+    private final StoreRepository storeRepository;
 
     @Transactional(readOnly = true)
     public Page<OrderStatusResDTO> getOrderListInOrderStatus(OrderStatus orderStatus, Pageable pageable) {
-        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findByStatus(orderStatus, pageable);
+        // 토큰에서 storeId 추출
+        UUID storeId = UUID.fromString(storeJwtClaimUtil.getStoreId());
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매장이 존재하지 않습니다."));
+
+        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findPageByStoreAndStatusWithin(
+                storeId,
+                orderStatus,
+                store.getBusinessOpenedAt(),
+                pageable);
+        System.out.println("storeId = " + storeId);
+        System.out.println("orderStatus = " + orderStatus);
+        System.out.println("store = " + store.getBusinessOpenedAt());
 
         return unitOrderPageList.map(OrderStatusResDTO::from);
     }

--- a/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -36,6 +37,10 @@ public class Store extends BaseIdAndTimeEntity {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Role role = Role.STORE;
+    @Column(name = "business_opened_at", nullable = false)
+    private LocalDateTime businessOpenedAt;
+    @Column(name = "business_closed_at")
+    private LocalDateTime businessClosedAt;
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,6 +55,7 @@ public class StoreService {
                 .ownerEmail(dto.getOwnerEmail())
                 .phoneNumber(dto.getPhoneNumber())
                 .password(passwordEncoder.encode(dto.getPassword()))
+                .businessOpenedAt(LocalDateTime.now())
                 .build();
 
         storeRepository.save(store);

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/MenuDetail.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/MenuDetail.java
@@ -1,7 +1,6 @@
 package com.beyond.jellyorder.domain.storetable.dto.orderTableStatus;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 


### PR DESCRIPTION
### 📋 작업 개요
주문 현황 리스트 조회 API 구현

<br/>


### 🔧 작업 상세
-  store테이블에 매장 개시(business_opened_at), 마감 시간(business_closed_at) 컬럼를 추가하였습니다.
추후 매장 개시 및 마감 기능을 위해 추가하였습니다.
각 매장별로 매장 오픈 이후 발생되는 주문건을 조회할 조건이 필요하기 때문에 추가하였습니다.

- 주문 상태값에 따라 unitOrder(단건주문)을 조회하는 로직을 구현했습니다.
1. 엔드포인트에 각 주문 상태값을 입력하여 조회할 수 있습니다. (ACCEPT, COMPLETE, CANCEL)
<img width="477" height="44" alt="스크린샷 2025-08-16 오후 9 32 49" src="https://github.com/user-attachments/assets/24f3e33a-c68f-4bd7-8560-1ab95fd948df" />

2. 페이지네이션을 적용하여 전체데이터가 아닌 20개의 주문들만 가져왔습니다.
<img width="852" height="620" alt="스크린샷 2025-08-16 오후 9 49 29" src="https://github.com/user-attachments/assets/832773e2-2bf8-4638-b6b4-8f0ec9706f36" />
<img width="850" height="893" alt="스크린샷 2025-08-16 오후 10 10 30" src="https://github.com/user-attachments/assets/de2fcb38-2a3e-4ef4-90fe-cdf6dd00d26f" />


<br/>


### 📌 이슈 번호
close #115 

<br/>


### ⚠️ 참고사항
N+1문제가 발생되기 때문에 추후 프로젝션 혹은 배치사이즈조절을 도입할 예정입니다.

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.