### PR TITLE
[Feat] 주문 상태 값 변경 API 구현 (#117)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/beyond/jellyorder/common/exception/CommonExceptionHandler.java
@@ -112,4 +112,17 @@ public class CommonExceptionHandler {
                         .status_message("잘못된 요청 형식입니다.")
                         .build());
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<?> illegalStateException(IllegalStateException e) {
+        log.error("[IllegalStateException] code = {}, message = {}", HttpStatus.BAD_REQUEST, e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonErrorDTO.builder()
+                        .status_message(e.getMessage())
+                        .status_code(HttpStatus.BAD_REQUEST.value())
+                        .build()
+
+                );
+    }
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
@@ -2,6 +2,8 @@ package com.beyond.jellyorder.domain.order.controller;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusUpdateReqDTO;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.UnitOrderStatusResDTO;
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.service.OrderStatusService;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +13,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +33,15 @@ public class OrderStatusController {
             ) {
         Page<OrderStatusResDTO> resDTOs = orderStatusService.getOrderListInOrderStatus(orderStatus, pageable);
         return ApiResponse.ok(resDTOs);
+    }
+
+    @PatchMapping("/{unitOrderId}/status")
+    public ResponseEntity<?> updateUnitOrderStatus(
+            @PathVariable UUID unitOrderId,
+            @RequestBody OrderStatusUpdateReqDTO reqDTO
+            ) {
+        UnitOrderStatusResDTO resDTO = orderStatusService.updateUnitOrderStatus(unitOrderId, reqDTO);
+        return ApiResponse.ok(resDTO);
     }
 
 

--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
@@ -1,0 +1,57 @@
+package com.beyond.jellyorder.domain.order.controller;
+
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.service.OrderStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order-status")
+@PreAuthorize("hasRole('STORE')")
+public class OrderStatusController {
+
+    private final OrderStatusService orderStatusService;
+
+    @GetMapping("/{orderStatus}")
+    public ResponseEntity<?> getOrderListInOrderStatus(
+            @PathVariable OrderStatus orderStatus,
+            @PageableDefault(size = 20, sort = "localtime", direction = Sort.Direction.ASC)Pageable pageable
+            ) {
+        Page<OrderStatusResDTO> resDTOs = orderStatusService.getOrderListInOrderStatus(orderStatus, pageable);
+        return ApiResponse.ok(resDTOs);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/controller/OrderStatusController.java
@@ -29,7 +29,7 @@ public class OrderStatusController {
     @GetMapping("/{orderStatus}")
     public ResponseEntity<?> getOrderListInOrderStatus(
             @PathVariable OrderStatus orderStatus,
-            @PageableDefault(size = 20, sort = "localtime", direction = Sort.Direction.ASC)Pageable pageable
+            @PageableDefault(size = 20, sort = "acceptedAt", direction = Sort.Direction.ASC)Pageable pageable
             ) {
         Page<OrderStatusResDTO> resDTOs = orderStatusService.getOrderListInOrderStatus(orderStatus, pageable);
         return ApiResponse.ok(resDTOs);

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenu.java
@@ -1,0 +1,29 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.OrderMenu;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusMenu {
+    private String menuName;
+    private Integer menuQuantity;
+    private List<OrderStatusMenuOption> optionList;
+
+    public static OrderStatusMenu from(OrderMenu orderMenu) {
+        return OrderStatusMenu.builder()
+                .menuName(orderMenu.getMenu().getName())
+                .menuQuantity(orderMenu.getQuantity())
+                .optionList(orderMenu.getOrderMenuOptionList().stream()
+                        .map(OrderStatusMenuOption::from).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenuOption.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusMenuOption.java
@@ -1,0 +1,21 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.OrderMenuOption;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusMenuOption {
+    private String optionName;
+
+    public static OrderStatusMenuOption from(OrderMenuOption option) {
+        return OrderStatusMenuOption.builder()
+                .optionName(option.getSubOption().getName())
+                .build();
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusResDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusResDTO.java
@@ -1,0 +1,34 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderStatusResDTO {
+    private UUID unitOrderId;
+    private Integer orderNumber;
+    private String storeTableName;
+    private LocalTime localTime;
+    private List<OrderStatusMenu> orderMenuList;
+
+    public static OrderStatusResDTO from(UnitOrder unitOrder) {
+        return OrderStatusResDTO.builder()
+                .unitOrderId(unitOrder.getId())
+                .orderNumber(unitOrder.getOrderNumber())
+                .storeTableName(unitOrder.getTotalOrder().getStoreTable().getName()) // join이 너무 많음.
+                .localTime(unitOrder.getRelevantTime())
+                .orderMenuList(unitOrder.getOrderMenus().stream().map(OrderStatusMenu::from).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusUpdateReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/OrderStatusUpdateReqDTO.java
@@ -1,0 +1,13 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderStatusUpdateReqDTO {
+    private OrderStatus orderStatus;
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/UnitOrderStatusResDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/dto/orderStatus/UnitOrderStatusResDTO.java
@@ -1,0 +1,30 @@
+package com.beyond.jellyorder.domain.order.dto.orderStatus;
+
+
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UnitOrderStatusResDTO {
+    private UUID unitOrderId;
+    private OrderStatus status;
+    private LocalTime localTime;
+
+    public static UnitOrderStatusResDTO from(UnitOrder unitOrder) {
+        return UnitOrderStatusResDTO.builder()
+                .unitOrderId(unitOrder.getId())
+                .status(unitOrder.getStatus())
+                .localTime(unitOrder.getRelevantTime())
+                .build();
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/UnitOrder.java
@@ -54,7 +54,7 @@ public class UnitOrder extends BaseIdEntity {
 
     // 주문 상태의 따라 시간 값 추출 메서드
     public LocalTime getRelevantTime() {
-        return switch (status) {
+        return switch (this.status) {
             case ACCEPT   -> LocalTime.from(getAcceptedAt());
             case COMPLETE -> LocalTime.from(getCompletedAt());
             case CANCEL   -> LocalTime.from(getCancelledAt());

--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
@@ -4,8 +4,12 @@ import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,4 +19,22 @@ public interface UnitOrderRepository extends JpaRepository<UnitOrder, UUID> {
     List<UnitOrder> findAllByTotalOrderIdAndStatusNot(UUID totalOrderId, OrderStatus status);
 
     Page<UnitOrder> findByStatus(OrderStatus orderStatus, Pageable pageable);
+
+    // 상태 + 매장 + 시간 구간 + 페이징
+    @Query("""
+        select u
+        from UnitOrder u
+        join u.totalOrder t
+        join t.storeTable st
+        join st.store s
+        where s.id = :storeId
+          and u.status = :status
+          and u.acceptedAt >= :startAt
+        """)
+    Page<UnitOrder> findPageByStoreAndStatusWithin(
+            @Param("storeId") UUID storeId,
+            @Param("status") OrderStatus status,
+            @Param("startAt") LocalDateTime startAt,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/UnitOrderRepository.java
@@ -2,6 +2,8 @@ package com.beyond.jellyorder.domain.order.repository;
 
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +14,5 @@ public interface UnitOrderRepository extends JpaRepository<UnitOrder, UUID> {
     // 해당 인자값의 status가 아닌 totalOrder에 속한 unitOrder리스트 추출 메서드.
     List<UnitOrder> findAllByTotalOrderIdAndStatusNot(UUID totalOrderId, OrderStatus status);
 
+    Page<UnitOrder> findByStatus(OrderStatus orderStatus, Pageable pageable);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -1,0 +1,28 @@
+package com.beyond.jellyorder.domain.order.service;
+
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.entity.UnitOrder;
+import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderStatusService {
+
+    private final UnitOrderRepository unitOrderRepository;
+
+    @Transactional(readOnly = true)
+    public Page<OrderStatusResDTO> getOrderListInOrderStatus(OrderStatus orderStatus, Pageable pageable) {
+        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findByStatus(orderStatus, pageable);
+
+        return unitOrderPageList.map(OrderStatusResDTO::from);
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -1,9 +1,13 @@
 package com.beyond.jellyorder.domain.order.service;
 
+import com.beyond.jellyorder.common.auth.StoreJwtClaimUtil;
 import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
 import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
+import com.beyond.jellyorder.domain.store.entity.Store;
+import com.beyond.jellyorder.domain.store.repository.StoreRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -18,10 +23,24 @@ import java.util.List;
 public class OrderStatusService {
 
     private final UnitOrderRepository unitOrderRepository;
+    private final StoreJwtClaimUtil storeJwtClaimUtil;
+    private final StoreRepository storeRepository;
 
     @Transactional(readOnly = true)
     public Page<OrderStatusResDTO> getOrderListInOrderStatus(OrderStatus orderStatus, Pageable pageable) {
-        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findByStatus(orderStatus, pageable);
+        // 토큰에서 storeId 추출
+        UUID storeId = UUID.fromString(storeJwtClaimUtil.getStoreId());
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 매장이 존재하지 않습니다."));
+
+        Page<UnitOrder> unitOrderPageList = unitOrderRepository.findPageByStoreAndStatusWithin(
+                storeId,
+                orderStatus,
+                store.getBusinessOpenedAt(),
+                pageable);
+        System.out.println("storeId = " + storeId);
+        System.out.println("orderStatus = " + orderStatus);
+        System.out.println("store = " + store.getBusinessOpenedAt());
 
         return unitOrderPageList.map(OrderStatusResDTO::from);
     }

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -2,6 +2,9 @@ package com.beyond.jellyorder.domain.order.service;
 
 import com.beyond.jellyorder.common.auth.StoreJwtClaimUtil;
 import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.OrderStatusUpdateReqDTO;
+import com.beyond.jellyorder.domain.order.dto.orderStatus.UnitOrderStatusResDTO;
+import com.beyond.jellyorder.domain.order.entity.OrderMenu;
 import com.beyond.jellyorder.domain.order.entity.OrderStatus;
 import com.beyond.jellyorder.domain.order.entity.UnitOrder;
 import com.beyond.jellyorder.domain.order.repository.UnitOrderRepository;
@@ -26,6 +29,7 @@ public class OrderStatusService {
     private final StoreJwtClaimUtil storeJwtClaimUtil;
     private final StoreRepository storeRepository;
 
+    // TODO: N+1문제 해결
     @Transactional(readOnly = true)
     public Page<OrderStatusResDTO> getOrderListInOrderStatus(OrderStatus orderStatus, Pageable pageable) {
         // 토큰에서 storeId 추출
@@ -43,5 +47,37 @@ public class OrderStatusService {
         System.out.println("store = " + store.getBusinessOpenedAt());
 
         return unitOrderPageList.map(OrderStatusResDTO::from);
+    }
+
+    /**
+     * 필수 로직 변환 작업
+     * 추후 redis 재고 도입으로 인한 리팩토링 필요함.
+     */
+    // 접수된 주문 상태변경(주문완료, 취소) 로직
+    public UnitOrderStatusResDTO updateUnitOrderStatus(UUID unitOrderId, OrderStatusUpdateReqDTO reqDTO) {
+        UnitOrder unitOrder = unitOrderRepository.findById(unitOrderId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 단건주문이 존재하지 않습니다."));
+
+        OrderStatus reqOrderStatus = reqDTO.getOrderStatus();
+
+        // 상태 전이 검증 로직 (예: 이미 COMPLETE면 다시 CANCEL 불가)
+        if (unitOrder.getStatus() == OrderStatus.COMPLETE || unitOrder.getStatus() == OrderStatus.CANCEL) {
+            throw new IllegalStateException("이미 완료되었거나 취소된 주문은 상태를 변경할 수 없습니다.");
+        }
+
+        if (reqOrderStatus == OrderStatus.COMPLETE) {
+            unitOrder.updateOrderStatus(OrderStatus.COMPLETE);
+        } else if (reqOrderStatus == OrderStatus.CANCEL) {
+            // 하루 판매 감소
+            // TODO: {동시성 제어를 위한 Redis 도입 예정}
+            unitOrder.getOrderMenus().forEach(orderMenu -> {
+                orderMenu.getMenu().decreaseSalesToday(orderMenu.getQuantity());
+            });
+
+            // 상태변경
+            unitOrder.updateOrderStatus(OrderStatus.CANCEL);
+        }
+
+        return UnitOrderStatusResDTO.from(unitOrder);
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/entity/Store.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -36,6 +37,10 @@ public class Store extends BaseIdAndTimeEntity {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Role role = Role.STORE;
+    @Column(name = "business_opened_at", nullable = false)
+    private LocalDateTime businessOpenedAt;
+    @Column(name = "business_closed_at")
+    private LocalDateTime businessClosedAt;
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;

--- a/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/store/service/StoreService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,6 +55,7 @@ public class StoreService {
                 .ownerEmail(dto.getOwnerEmail())
                 .phoneNumber(dto.getPhoneNumber())
                 .password(passwordEncoder.encode(dto.getPassword()))
+                .businessOpenedAt(LocalDateTime.now())
                 .build();
 
         storeRepository.save(store);

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/MenuDetail.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/MenuDetail.java
@@ -1,7 +1,6 @@
 package com.beyond.jellyorder.domain.storetable.dto.orderTableStatus;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 


### PR DESCRIPTION
### 📋 작업 개요
주문 상태 값 변경 API 구현
<br/>


### 🔧 작업 상세
- 현재 접수된 주문들을 '조리완료', '주문취소' 가 가능하도록 상태를 변경하는 로직을 구성했습니다.
- Patch메서드를 통한 수정 요청이며, 엔드포엔트에 UnitOrder의 id값을 url에 포함 및 http body부분에 원하는 status값을 요청합니다.
- 주문 취소의 경우 주문했던 메뉴의 하루판매량을 다시 감소하는 로직을 구현했습니다.
- 테스트 예시 (조리완료)
<img width="860" height="541" alt="스크린샷 2025-08-16 오후 11 41 51" src="https://github.com/user-attachments/assets/66240211-6822-46b2-a3fa-3cd77bda5e45" />
<img width="920" height="44" alt="스크린샷 2025-08-16 오후 11 42 11" src="https://github.com/user-attachments/assets/6969029f-0e0a-4359-91b1-4748c91d8812" />

- 테스트 예시 (주문취소)
<img width="842" height="531" alt="스크린샷 2025-08-16 오후 11 55 13" src="https://github.com/user-attachments/assets/67972079-7c63-4c44-8f75-ec867679f697" />
<img width="906" height="14" alt="스크린샷 2025-08-16 오후 11 55 47" src="https://github.com/user-attachments/assets/55a818ee-a0da-40e0-aa29-66de99b8d19c" />

- 취소된 재고 하루판매량 감소
<img width="114" height="54" alt="스크린샷 2025-08-16 오후 11 55 58" src="https://github.com/user-attachments/assets/2ad78397-12e4-4e96-b10a-1b4598d83e25" />
<img width="112" height="60" alt="스크린샷 2025-08-16 오후 11 56 05" src="https://github.com/user-attachments/assets/7c089b12-dafe-4a06-8534-7daf48132075" />

<br/>


### 📌 이슈 번호
close #117 
<br/>


### ⚠️ 참고사항
- 주문 취소 시 동시성 이슈가 발생할 수 있기 때문에 추후 redis도입이 필요해 보입니다.
<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.