### PR TITLE
[Feat] 메뉴 수정 기능 구현 (#111)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/controller/MenuController.java
@@ -7,6 +7,7 @@ import com.beyond.jellyorder.domain.option.dto.OptionAddReqDto;
 import com.beyond.jellyorder.domain.option.dto.OptionAddResDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -58,5 +59,17 @@ public class MenuController {
     public ResponseEntity<?> deleteMenu(@RequestBody @Valid MenuDeleteReqDto reqDto) {
         menuService.deleteMenuById(reqDto.getMenuId());
         return ApiResponse.ok(null, "메뉴가 정상적으로 삭제되었습니다.");
+    }
+
+    @PutMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('STORE')")
+    public ResponseEntity<?> updateMenu(
+            @ModelAttribute @Valid MenuUpdateReqDto reqDto
+    ) {
+        // PathVariable → DTO로 주입 (클라이언트 body에 menuId 보낼 필요 없음)
+        reqDto.setMenuId(reqDto.getMenuId());
+
+        MenuAdminResDto res = menuService.update(reqDto);
+        return ApiResponse.ok(res, "메뉴가 수정되었습니다.");
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuUpdateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuUpdateReqDto.java
@@ -1,0 +1,52 @@
+package com.beyond.jellyorder.domain.menu.dto;
+
+import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuUpdateReqDto {
+
+    // 컨트롤러에서 PathVariable 주입
+    @NotNull(message = "menuId는 필수입니다.")
+    private UUID menuId;
+
+    // 카테고리 변경 가능
+    @NotBlank(message = "카테고리명은 필수입니다.")
+    private String categoryName;
+
+    @NotBlank(message = "메뉴 이름은 필수입니다.")
+    @Size(max = 30)
+    private String name;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(0)
+    private Integer price;
+
+    @NotBlank(message = "설명은 필수입니다.")
+    @Size(max = 255)
+    private String description;
+
+    @Size(max = 255)
+    private String origin;
+
+    @Min(-1)
+    private Integer salesLimit; // 기본 -1
+
+    // 재고/판매 상태 정책에 따라 사용 (예: 수동품절 토글 또는 onSale 표기)
+    private Boolean onSale; // null이면 변경 안 함
+
+    // 이미지 교체 없으면 null/empty로 전송
+    private MultipartFile imageFile;
+
+    // 전체 스냅샷
+    private List<MainOptionDto> mainOptions;   // 메인/서브 옵션 트리
+}

--- a/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/service/MenuService.java
@@ -21,6 +21,7 @@ import com.beyond.jellyorder.domain.option.subOption.dto.SubOptionDto;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -289,6 +290,236 @@ public class MenuService {
 
         // 5) 메뉴 삭제 (옵션 등 cascade 삭제 포함)
         menuRepository.delete(menu);
+    }
+
+    public MenuAdminResDto update(MenuUpdateReqDto dto) {
+        final UUID storeUuid = UUID.fromString(storeJwtClaimUtil.getStoreId());
+
+        // 0) 매장 검증
+        storeRepository.findById(storeUuid)
+                .orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeUuid));
+
+        // 1) 메뉴 조회 + 소속 검증
+        Menu menu = menuRepository.findById(dto.getMenuId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 메뉴를 찾을 수 없습니다."));
+
+        UUID menuStoreId = menu.getCategory() != null ? menu.getCategory().getStore().getId() : null; // Category에 storeId 필드 있다고 가정
+        if (menuStoreId == null || !menuStoreId.equals(storeUuid)) {
+            throw new AccessDeniedException("해당 메뉴는 현재 매장의 소속이 아닙니다.");
+        }
+
+        // 2) 카테고리 변경
+        if (dto.getCategoryName() != null &&
+                !dto.getCategoryName().equals(menu.getCategory().getName())) {
+            Category newCategory = categoryRepository.findByStoreIdAndName(storeUuid, dto.getCategoryName())
+                    .orElseThrow(() -> new EntityNotFoundException("카테고리 없음: " + dto.getCategoryName()));
+            menu.setCategory(newCategory);
+        }
+
+        // 3) 스칼라 필드 변경 (필요 시만 set)
+        if (dto.getName() != null && !Objects.equals(menu.getName(), dto.getName())) {
+            menu.setName(dto.getName());
+        }
+        if (dto.getPrice() != null && !Objects.equals(menu.getPrice(), dto.getPrice())) {
+            menu.setPrice(dto.getPrice());
+        }
+        if (dto.getDescription() != null && !Objects.equals(menu.getDescription(), dto.getDescription())) {
+            menu.setDescription(dto.getDescription());
+        }
+        if (dto.getOrigin() != null && !Objects.equals(menu.getOrigin(), dto.getOrigin())) {
+            menu.setOrigin(dto.getOrigin());
+        }
+        if (dto.getSalesLimit() != null) {
+            Integer newLimit = dto.getSalesLimit();
+            if (!Objects.equals(menu.getSalesLimit(), newLimit)) {
+                menu.setSalesLimit(newLimit);
+            }
+        }
+        // onSale 정책: 필요 시 수동 품절 토글로 연결
+        if (dto.getOnSale() != null) {
+            if (dto.getOnSale()) {
+                // 수동 품절 해제
+                if (menu.getStockStatus() == MenuStatus.SOLD_OUT_MANUAL) {
+                    menu.markOnSale();
+                }
+            } else {
+                // 수동 품절로 전환
+                menu.markSoldOutManually();
+            }
+        }
+
+        // 4) 이미지 교체 (성공 후 기존 삭제)
+        if (dto.getImageFile() != null && !dto.getImageFile().isEmpty()) {
+            String oldUrl = menu.getImageUrl();
+            String newUrl = s3Manager.upload(dto.getImageFile(), "menus");
+            menu.setImageUrl(newUrl);
+            if (oldUrl != null) {
+                s3Manager.delete(oldUrl);
+            }
+        }
+
+
+        // 6) 옵션 트리 동기화 (이름 기반 diff)
+        syncOptions(menu, dto.getMainOptions());
+
+        // 7) 재고 상태 재계산
+        if (menu.getStockStatus() != MenuStatus.SOLD_OUT_MANUAL) {
+            MenuStatus computed = deriveStockStatusFromIngredients(menu);
+            menu.changeStockStatus(computed);
+        }
+
+        // 8) 응답
+        return MenuAdminResDto.fromEntity(menu);
+    }
+
+    /* =================== 동기화/도우미 메서드 =================== */
+
+    private void syncIngredients(Menu menu, List<String> requestedNames, UUID storeUuid) {
+        List<String> req = Optional.ofNullable(requestedNames).orElseGet(List::of).stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .distinct()
+                .toList();
+
+        // 현재 (ingredientId -> MenuIngredient)
+        Map<UUID, MenuIngredient> current = Optional.ofNullable(menu.getMenuIngredients())
+                .orElseGet(List::of).stream()
+                .filter(mi -> mi.getIngredient() != null)
+                .collect(Collectors.toMap(mi -> mi.getIngredient().getId(), mi -> mi));
+
+        // 요청을 엔티티로 resolve (ingredientId -> Ingredient)
+        Map<UUID, Ingredient> desired = new HashMap<>();
+        for (String name : req) {
+            Ingredient ing = ingredientRepository.findByStoreIdAndName(storeUuid, name)
+                    .orElseThrow(() -> new EntityNotFoundException("식자재 없음: " + name));
+            desired.put(ing.getId(), ing);
+        }
+
+        // 제거
+        if (menu.getMenuIngredients() != null) {
+            for (UUID ingId : new ArrayList<>(current.keySet())) {
+                if (!desired.containsKey(ingId)) {
+                    menu.getMenuIngredients().remove(current.get(ingId));
+                }
+            }
+        } else {
+            menu.setMenuIngredients(new ArrayList<>());
+        }
+
+        // 추가
+        for (Map.Entry<UUID, Ingredient> e : desired.entrySet()) {
+            if (!current.containsKey(e.getKey())) {
+                MenuIngredient mi = MenuIngredient.builder()
+                        .menu(menu)
+                        .ingredient(e.getValue())
+                        .build();
+                menu.addMenuIngredient(mi); // 편의 메서드
+            }
+        }
+    }
+
+    private void syncOptions(Menu menu, List<MainOptionDto> requestedMainDtos) {
+        List<MainOptionDto> req = Optional.ofNullable(requestedMainDtos).orElseGet(List::of);
+
+        // 현재 main 맵 (name -> entity)
+        Map<String, MainOption> currMain = Optional.ofNullable(menu.getMainOptions())
+                .orElseGet(List::of).stream()
+                .collect(Collectors.toMap(MainOption::getName, mo -> mo, (a, b) -> a, LinkedHashMap::new));
+
+        // 요청 main 맵 (name -> dto) + 검증
+        Map<String, MainOptionDto> desiredMain = req.stream()
+                .peek(dto -> {
+                    String n = (dto.getName() == null ? "" : dto.getName().trim());
+                    if (n.isEmpty()) throw new IllegalArgumentException("메인 옵션 이름은 필수입니다.");
+                })
+                .collect(Collectors.toMap(
+                        m -> m.getName().trim(),
+                        m -> m,
+                        (a, b) -> { throw new IllegalArgumentException("중복 메인 옵션: " + a.getName()); },
+                        LinkedHashMap::new
+                ));
+
+        // 제거될 main
+        if (menu.getMainOptions() != null) {
+            for (String name : new ArrayList<>(currMain.keySet())) {
+                if (!desiredMain.containsKey(name)) {
+                    menu.getMainOptions().remove(currMain.get(name)); // orphanRemoval
+                }
+            }
+        } else {
+            menu.setMainOptions(new ArrayList<>());
+        }
+
+        // 추가/수정 main
+        for (Map.Entry<String, MainOptionDto> e : desiredMain.entrySet()) {
+            String name = e.getKey();
+            MainOptionDto dto = e.getValue();
+
+            if (!currMain.containsKey(name)) {
+                // 추가
+                MainOption newMo = dto.toEntity(); // 내부에서 subOptions DTO→엔티티 변환/검증
+                newMo.setMenu(menu);
+                if (newMo.getSubOptions() != null) {
+                    for (SubOption so : newMo.getSubOptions()) {
+                        so.setMainOption(newMo);
+                    }
+                }
+                menu.getMainOptions().add(newMo);
+            } else {
+                // 수정: 서브옵션 동기화
+                MainOption mo = currMain.get(name);
+                syncSubOptions(mo, dto.getSubOptions());
+            }
+        }
+    }
+
+    private void syncSubOptions(MainOption mo, List<SubOptionDto> requestedSubs) {
+        List<SubOptionDto> req = Optional.ofNullable(requestedSubs).orElseGet(List::of);
+
+        Map<String, SubOption> curr = Optional.ofNullable(mo.getSubOptions())
+                .orElseGet(List::of).stream()
+                .collect(Collectors.toMap(SubOption::getName, so -> so, (a, b) -> a, LinkedHashMap::new));
+
+        Map<String, SubOptionDto> desired = req.stream()
+                .peek(d -> {
+                    String n = (d.getName() == null ? "" : d.getName().trim());
+                    if (n.isEmpty()) throw new IllegalArgumentException("서브 옵션 이름은 필수입니다.");
+                    if (d.getPrice() == null || d.getPrice() < 0) throw new IllegalArgumentException("서브 옵션 가격은 0 이상이어야 합니다.");
+                })
+                .collect(Collectors.toMap(
+                        d -> d.getName().trim(),
+                        d -> d,
+                        (a, b) -> { throw new IllegalArgumentException("중복 서브 옵션: " + a.getName()); },
+                        LinkedHashMap::new
+                ));
+
+        // 제거
+        if (mo.getSubOptions() != null) {
+            for (String name : new ArrayList<>(curr.keySet())) {
+                if (!desired.containsKey(name)) {
+                    mo.getSubOptions().remove(curr.get(name)); // orphanRemoval
+                }
+            }
+        } else {
+            mo.setSubOptions(new ArrayList<>());
+        }
+
+        // 추가/수정
+        for (Map.Entry<String, SubOptionDto> e : desired.entrySet()) {
+            String name = e.getKey();
+            SubOptionDto dto = e.getValue();
+            if (!curr.containsKey(name)) {
+                SubOption so = SubOption.builder().name(name).price(dto.getPrice()).build();
+                so.setMainOption(mo);
+                mo.getSubOptions().add(so);
+            } else {
+                SubOption so = curr.get(name);
+                if (!Objects.equals(so.getPrice(), dto.getPrice())) {
+                    so.setPrice(dto.getPrice());
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴 수정 기능 구현 (DTO 정의, Service 로직, Controller API 추가)

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuUpdateReqDto 추가
  - 카테고리명, 메뉴명, 가격, 설명, 원산지, 판매 제한 등 필드 정의
  - 이미지 파일(MultipartFile) 및 메인/서브 옵션 트리 포함
  - NotBlank, Size, Min 등 유효성 검증 어노테이션 적용
- Service update 로직 구현
  - 매장 소속 검증 및 메뉴 소속 일치 여부 확인
  - 카테고리 변경 처리 및 스칼라 필드(name/price/description/origin/salesLimit) 갱신
  - onSale 정책(수동 품절/해제 토글) 반영 및 재고 상태 자동 재계산
  - 이미지 교체(S3 업로드 후 기존 삭제) 로직 추가
  - 옵션 트리(MainOption/SubOption) 및 식자재 동기화 로직 구현
- Controller API 추가
  - PutMapping("/update"), consumes = MULTIPART_FORM_DATA 적용
  - ModelAttribute Valid MenuUpdateReqDto 바인딩 및 검증
  - PreAuthorize("hasRole('STORE')") 보안 적용
  - 수정 성공 시 MenuAdminResDto 반환

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #111 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 옵션 트리 및 식자재 동기화는 이름 기반 diff 방식으로 동작하므로, 클라이언트에서 중복/빈 이름 전송 시 예외 발생 가능
- 이미지 교체는 S3 업로드 성공 후 기존 이미지 삭제하도록 구현되어 있음

### 테스트 결과:
<img width="1508" height="829" alt="image" src="https://github.com/user-attachments/assets/2fff96c1-6efc-4a7d-9887-ce8f6024d5cc" />
<img width="1676" height="96" alt="image" src="https://github.com/user-attachments/assets/66c738af-5ba7-4eb1-9995-8042bd9ddb14" />
<img width="1516" height="942" alt="image" src="https://github.com/user-attachments/assets/a1e7f34a-6744-4aa2-81f6-d6756c10b4da" />
<img width="1515" height="945" alt="image" src="https://github.com/user-attachments/assets/dbacc0fc-4e6a-4ce8-ae12-24d5ffdfee7d" />


<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.