### PR TITLE
[Fix] 식자재 삭제 시 메뉴 상태 복원 로직 추가 (#139)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuIngredientRepository.java
@@ -1,8 +1,30 @@
 package com.beyond.jellyorder.domain.menu.repository;
 
+import com.beyond.jellyorder.domain.ingredient.domain.Ingredient;
 import com.beyond.jellyorder.domain.menu.domain.MenuIngredient;
 import com.beyond.jellyorder.domain.menu.domain.MenuIngredientId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
 
 public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, MenuIngredientId> {
+    @Query("""
+        select distinct m.id
+        from MenuIngredient mi
+        join mi.menu m
+        where mi.ingredient = :ingredient
+    """)
+    List<UUID> findMenuIdsByIngredient(@Param("ingredient") Ingredient ingredient);
+
+    @Query("""
+           select count(mi)
+           from MenuIngredient mi
+           where mi.menu.id = :menuId
+             and mi.ingredient.status = com.beyond.jellyorder.domain.ingredient.domain.IngredientStatus.EXHAUSTED
+           """)
+    long countExhaustedByMenuId(@Param("menuId") UUID menuId);
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
식자재 삭제 시 메뉴 상태 복원 로직 추가

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- 삭제된 식자재로 인해 OUT_OF_STOCK 되었던 메뉴가 판매제한 소진이 아니고 남아있는 식자재가 모두 EXHAUSTED가 아닐 경우 ON_SALE로 복구
- MenuIngredientRepository에 `countExhaustedByMenuId` 쿼리 추가하여 메뉴별 남은 소진 상태 식자재 개수 확인 가능
- IngredientService.delete 로직 내 메뉴 상태 재평가 및 상태 복원 처리 추가

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #139 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- SOLD_OUT_MANUAL 상태의 메뉴는 복원 로직에서 제외됨
- 판매제한(salesLimit) 소진 상태인 경우에는 상태 OUT_OF_STOCK 상태 유지

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.