### PR TITLE
[Feat, Fix] 새 카테고리 설명 지원 + 식자재 ID 기반 연동 + MenuService 로직 보강 (#141)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
@@ -19,6 +19,10 @@ public class MenuCreateReqDto {
     @NotNull(message = "카테고리명은 필수입니다.")
     private String categoryName;
 
+    // 새 카테고리를 만들 때만 사용 (선택)
+    @Size(max = 255)
+    private String categoryDescription;
+
     @NotBlank(message = "메뉴 이름(name)은 필수입니다.")
     @Size(max = 30, message = "메뉴 이름은 30자 이하로 입력해주세요.")
     private String name;

--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuUpdateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuUpdateReqDto.java
@@ -23,6 +23,10 @@ public class MenuUpdateReqDto {
     @NotBlank(message = "카테고리명은 필수입니다.")
     private String categoryName;
 
+    // 새 카테고리를 만들 때만 사용 (선택)
+    @Size(max = 255)
+    private String categoryDescription;
+
     @NotBlank(message = "메뉴 이름은 필수입니다.")
     @Size(max = 30)
     private String name;
@@ -49,4 +53,6 @@ public class MenuUpdateReqDto {
 
     // 전체 스냅샷
     private List<MainOptionDto> mainOptions;   // 메인/서브 옵션 트리
+
+    private List<UUID> ingredientIds;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -1,7 +1,11 @@
 package com.beyond.jellyorder.domain.menu.repository;
 
 import com.beyond.jellyorder.domain.menu.domain.Menu;
+import com.beyond.jellyorder.domain.menu.domain.MenuStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴 수정/생성 흐름 확장: 새 카테고리 설명 지원 + 식자재 ID 기반 연동 + MenuService 로직 보강

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- **DTO 확장**
  - `MenuCreateReqDto`에 `categoryDescription` 추가(선택, 최대 255자) — 새 카테고리 생성 시 설명 입력 지원
  - `MenuUpdateReqDto`에 `categoryDescription`, `ingredientIds` 추가 — 수정 시 카테고리 설명 반영 및 식자재 ID 기반 연동 가능
- **Service 로직 보강 (`MenuService`)**
  - 새 카테고리 생성 시 `categoryDescription`까지 저장되도록 처리
  - 카테고리 변경 시 존재하지 않으면 생성 후 메뉴에 할당
  - 식자재 연동을 **이름 기반 → ID 기반**으로 전환: `syncIngredientsByIds(menu, requestedIds, storeUuid)`
    - 존재하지 않는 식자재/타 매장 소속 식자재에 대한 예외 처리 강화
- **기타**
  - 불필요한 중복 로직 정리 및 NPE 방지용 방어 코드 추가

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #141 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- `categoryDescription`은 **새 카테고리 생성 시에만** 의미가 있으며, 기존 카테고리 선택 시 무시됩니다.
- 식자재 연동은 이제 **ID 기준**으로만 동작하므로, 프론트엔드에서 `ingredientIds` 전달이 보장되어야 합니다.

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.