### PR TITLE
[Chore] 주문 취소 시 TotalOrder의 가격 변경 로직 추가 (#145)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
@@ -64,4 +64,9 @@ public class TotalOrder extends BaseIdEntity {
     public void updatePaymentedAt(LocalDateTime paidAt) {
         this.paymentedAt = paidAt;
     }
+
+    // 총 가격 감소 메서드
+    public void decreaseTotalPrice(Integer decreasePrice) {
+        this.totalPrice -= decreasePrice;
+    }
 }


### PR DESCRIPTION
### 📋 작업 개요
주문 취소 시 TotalOrder의 가격 변경 로직 추가

<br/>


### 🔧 작업 상세
- 기존 로직은 추문을 취소하더도 totalOrder의 가격이 변하지 않았습니다.
- 주문 취소하게 되면 해당 UnitOrder의 속해있는 모든 가격을 계산하여 TotalOrder의 가격을 감소시켰습니다.

<br/>


### 📌 이슈 번호
close #145 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.