### PR TITLE
Feat: 메뉴 생성 로직/DTO 리팩터 — ingredientIds(UUID) 도입 (#169)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/dto/MenuCreateReqDto.java
@@ -2,6 +2,7 @@ package com.beyond.jellyorder.domain.menu.dto;
 
 import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.menu.domain.Menu;
+import com.beyond.jellyorder.domain.menu.domain.MenuStatus;
 import com.beyond.jellyorder.domain.option.mainOption.dto.MainOptionDto;
 import jakarta.validation.constraints.*;
 import lombok.*;
@@ -9,62 +10,72 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class MenuCreateReqDto {
-    @NotNull(message = "카테고리명은 필수입니다.")
+
+    @NotBlank(message = "카테고리명은 필수입니다.")
     private String categoryName;
 
-    // 새 카테고리를 만들 때만 사용 (선택)
     @Size(max = 255)
     private String categoryDescription;
 
-    @NotBlank(message = "메뉴 이름(name)은 필수입니다.")
+    @NotBlank(message = "메뉴 이름은 필수입니다.")
     @Size(max = 30, message = "메뉴 이름은 30자 이하로 입력해주세요.")
     private String name;
 
-    @NotNull(message = "가격(price)은 필수입니다.")
+    @NotNull(message = "가격은 필수입니다.")
     @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private Integer price;
 
-    @NotBlank(message = "설명(description)은 필수입니다.")
+    @NotBlank(message = "설명은 필수입니다.")
     @Size(max = 255, message = "설명은 255자 이하로 입력해주세요.")
     private String description;
 
-    @Size(max = 255, message = "원산지(origin)는 255자 이하로 입력해주세요.")
+    @Size(max = 255, message = "원산지는 255자 이하로 입력해주세요.")
     private String origin;
 
     @Min(value = -1, message = "판매 한도는 -1 이상이어야 합니다.")
     private Integer salesLimit = -1;
 
+    /**
+     * 신규 생성 시 연결할 식자재 ID 목록
+     * multipart/form-data에서는 JSON 문자열 배열로 전송
+     */
     @Builder.Default
-    private List<String> ingredients = new ArrayList<>();
+    private List<UUID> ingredientIds = new ArrayList<>();
 
-    @NotNull(message = "이미지 파일(imageFile)은 필수입니다.")
-    private MultipartFile imageFile;
-
+    /**
+     * 옵션 트리 (메인/서브 옵션 구조)
+     */
     private List<MainOptionDto> mainOptions;
 
-    @Builder.Default
-    private boolean onSale = true;
+    @NotNull(message = "이미지 파일은 필수입니다.")
+    private MultipartFile imageFile;
 
+    /**
+     * 엔티티 변환
+     */
     public Menu toEntity(Category category, String imageUrl) {
         if (category == null) throw new IllegalArgumentException("카테고리는 필수입니다.");
         if (imageUrl == null || imageUrl.isBlank()) throw new IllegalArgumentException("이미지 URL은 필수입니다.");
 
         return Menu.builder()
                 .category(category)
-                .name(getName())
-                .price(getPrice())
-                .description(getDescription())
+                .name(name)
+                .price(price)
+                .description(description)
                 .imageUrl(imageUrl)
-                .origin(getOrigin())
-                .salesLimit(getSalesLimit() != null ? getSalesLimit() : -1)
+                .origin(origin)
+                .salesLimit(salesLimit != null ? salesLimit : -1)
                 .salesToday(0)
+                // 생성 시 기본은 ON_SALE, 이후 식자재 동기화 로직에서 상태 재계산됨
+                .stockStatus(MenuStatus.ON_SALE)
                 .build();
     }
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  

<br/>

## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- MenuService.create 리팩터
- 식자재: ID 기반 연동(ingredientIds)으로 동기화, 타 매장 식자재 차단
- 재고: 수동품절이 아닌 경우 식자재 상태로 재계산(소진 → OUT_OF_STOCK, 그 외 ON_SALE).

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #169 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.