### PR TITLE
[Refactor] 카운터 결제 API 수정 (#176)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/entity/TotalOrder.java
@@ -5,6 +5,7 @@ import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.security.PublicKey;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,5 +69,15 @@ public class TotalOrder extends BaseIdEntity {
     // 총 가격 감소 메서드
     public void decreaseTotalPrice(Integer decreasePrice) {
         this.totalPrice -= decreasePrice;
+    }
+
+    // 주문 완료 시간 변경
+    public void updateEndedAt(LocalDateTime endedAt) {
+        this.endedAt = endedAt;
+    }
+
+    // 정산 금액 변환 메서드
+    public Long changeSettlementAmount() {
+        return (long) (this.totalPrice * 0.9);
     }
 }

--- a/src/main/java/com/beyond/jellyorder/domain/sales/controller/SalesController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sales/controller/SalesController.java
@@ -1,6 +1,7 @@
 package com.beyond.jellyorder.domain.sales.controller;
 
 
+import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.common.exception.CommonErrorDTO;
 import com.beyond.jellyorder.domain.order.entity.TotalOrder;
 import com.beyond.jellyorder.domain.order.repository.TotalOrderRepository;
@@ -117,7 +118,7 @@ public class SalesController {
     // 카운터 결제 선택 (식사 후)
     @PreAuthorize("hasRole('STORE')")
     @PostMapping("/counter/choose")
-    public ResponseEntity<String> counterChoose(@RequestBody OrderIdReqDto req) {
+    public ResponseEntity<String> counterChoose(@RequestBody OrderIdReqDto req){
         UUID orderId = req.getOrderId();
 
         // orderId 유효성 체크
@@ -148,4 +149,14 @@ public class SalesController {
 
         return ResponseEntity.ok().build();
     }
+
+    // 카운터 결제 처리(NEW! - 형진 개발)
+    @PreAuthorize("hasRole('STORE')")
+    @PostMapping("/counter-payment")
+    public ResponseEntity<?> processPayment(@RequestBody CounterPaymentReqDTO reqDTO) {
+        salesService.processPayment(reqDTO);
+
+        return ApiResponse.ok(null, "결제처리가 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/com/beyond/jellyorder/domain/sales/dto/CounterPaymentReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sales/dto/CounterPaymentReqDTO.java
@@ -1,0 +1,16 @@
+package com.beyond.jellyorder.domain.sales.dto;
+
+import com.beyond.jellyorder.domain.sales.entity.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CounterPaymentReqDTO {
+    private UUID totalOrderId;
+    private PaymentMethod method;   // CARD or CASH
+}

--- a/src/main/java/com/beyond/jellyorder/domain/sales/entity/Sales.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sales/entity/Sales.java
@@ -3,7 +3,6 @@ package com.beyond.jellyorder.domain.sales.entity;
 import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
 import com.beyond.jellyorder.domain.order.entity.TotalOrder;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -30,7 +29,7 @@ public class Sales extends BaseIdAndTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private Status status;
+    private SalesStatus status;
 
     @Column(name = "total_amount")
     private Long totalAmount;
@@ -48,7 +47,7 @@ public class Sales extends BaseIdAndTimeEntity {
     @PrePersist // Entity가 DB에 insert 되기 전에 호출됨
     void prePersist() {
         if (status == null) {
-            status = Status.PENDING;
+            status = SalesStatus.PENDING;
         }
         validateConsistency(false);
     }
@@ -68,7 +67,7 @@ public class Sales extends BaseIdAndTimeEntity {
             throw new IllegalStateException("COUNTER 결제는 QR을 사용할 수 없습니다.");
         }
         // COMPLETED면 필수값 검증
-        if (status == Status.COMPLETED) {
+        if (status == SalesStatus.COMPLETED) {
             if (paidAt == null) {
                 throw new IllegalStateException("COMPLETED 상태에는 paid_at이 필요합니다.");
             }

--- a/src/main/java/com/beyond/jellyorder/domain/sales/entity/SalesStatus.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sales/entity/SalesStatus.java
@@ -1,7 +1,7 @@
 package com.beyond.jellyorder.domain.sales.entity;
 
 /** 결제 상태 */
-public enum Status {
+public enum SalesStatus {
     COMPLETED,
     CANCELLED,
     PENDING

--- a/src/main/java/com/beyond/jellyorder/domain/sales/service/SalesService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sales/service/SalesService.java
@@ -1,11 +1,10 @@
 package com.beyond.jellyorder.domain.sales.service;
 
 import com.beyond.jellyorder.domain.order.entity.TotalOrder;
-import com.beyond.jellyorder.domain.order.repository.TotalOrderRepository;
 import com.beyond.jellyorder.domain.sales.entity.OrderType;
 import com.beyond.jellyorder.domain.sales.entity.PaymentMethod;
 import com.beyond.jellyorder.domain.sales.entity.Sales;
-import com.beyond.jellyorder.domain.sales.entity.Status;
+import com.beyond.jellyorder.domain.sales.entity.SalesStatus;
 import com.beyond.jellyorder.domain.sales.repository.SalesRepository;
 import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
 import com.beyond.jellyorder.domain.storetable.entity.TableStatus;
@@ -31,7 +30,7 @@ public class SalesService {
         Sales sales = salesRepository.findByTotalOrderId(orderId).orElseGet(() ->
                 Sales.builder()
                         .totalOrder(em.getReference(TotalOrder.class, orderId))
-                        .status(Status.PENDING)
+                        .status(SalesStatus.PENDING)
                         .build()
         );
 
@@ -44,7 +43,7 @@ public class SalesService {
 
         sales.setOrderType(orderType);
         sales.setPaymentMethod(paymentMethod);
-        sales.setStatus(Status.PENDING);
+        sales.setStatus(SalesStatus.PENDING);
         sales.setTotalAmount(null);
         sales.setPaidAt(null);
         sales.setTid(null);
@@ -63,7 +62,7 @@ public class SalesService {
     public Sales complete(UUID orderId, PaymentMethod method, Long totalAmount, LocalDateTime paidAt) {
         Sales sales = getByOrderIdOrThrow(orderId);
 
-        if (sales.getStatus() != Status.PENDING) {
+        if (sales.getStatus() != SalesStatus.PENDING) {
             return sales; // 멱등 처리
         }
 
@@ -80,7 +79,7 @@ public class SalesService {
         }
 
         sales.setPaidAt(paidAt != null ? paidAt : LocalDateTime.now());
-        sales.setStatus(Status.COMPLETED);
+        sales.setStatus(SalesStatus.COMPLETED);
 
         // 결제 완료 후 테이블 status 리셋 && totalOrder의 paymentedAt 시간 업데이트
         TotalOrder totalOrder = sales.getTotalOrder();
@@ -112,10 +111,10 @@ public class SalesService {
     /** 취소 처리 */
     public Sales cancel(UUID orderId) {
         Sales sales = getByOrderIdOrThrow(orderId);
-        if (sales.getStatus() == Status.COMPLETED) {
+        if (sales.getStatus() == SalesStatus.COMPLETED) {
             throw new IllegalStateException("이미 COMPLETED 상태입니다.");
         }
-        sales.setStatus(Status.CANCELLED);
+        sales.setStatus(SalesStatus.CANCELLED);
         return sales;
     }
 

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/OrderMenuDetailPrice.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/OrderMenuDetailPrice.java
@@ -22,7 +22,7 @@ public class OrderMenuDetailPrice {
         return OrderMenuDetailPrice.builder()
                 .MenuName(orderMenu.getMenu().getName())
                 .MenuQuantity(orderMenu.getQuantity())
-                .MenuPrice(orderMenu.getMenu().getPrice() * orderMenu.getQuantity())
+                .MenuPrice(orderMenu.getMenu().getPrice())
                 .menuOptionList(menuOptionList)
                 .build();
     }

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/service/OrderTableStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/service/OrderTableStatusService.java
@@ -51,7 +51,7 @@ public class OrderTableStatusService {
 
                     // 테이블에 주문이 없거나 테이블 상태가 EATING이 아니면 null값 만 넘김.
                     if (totalOrderOpt.isEmpty()
-                            || table.getStatus() != TableStatus.EATING) {
+                            || table.getStatus() == TableStatus.STANDBY) {
                         return OrderTableResDTO.from(table, null, Collections.emptyList());
                     }
 


### PR DESCRIPTION
### 📋 작업 개요
카운터 결제 API 수정

<br/>


### 🔧 작업 상세
- 카운터 결제 시 현금, 카드 결제 처리 api 구현했습니다.
- 해당 total_order에 대한 CARD, CASH 중 선택하여 결제 처리했습니다.
- 결제 처리 시 서비스로직에서 sales엔티티 생성 및 저장, store_table의 상태값을 'STANBY'로 변경, total_order의 endedAt와paymentedAt 시간 업데이트하였습니다.
- 활성상태인 주문이 있을 시 롤백처리했습니다.

<br/>


### 📌 이슈 번호
close #176 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.