### PR TITLE
[Refactor] 주문테이블 수정 API 리팩토링 (#181)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/OrderMenuRepository.java
@@ -1,6 +1,8 @@
 package com.beyond.jellyorder.domain.order.repository;
 
 import com.beyond.jellyorder.domain.order.entity.OrderMenu;
+import com.beyond.jellyorder.domain.order.entity.OrderStatus;
+import com.beyond.jellyorder.domain.order.entity.TotalOrder;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -48,6 +50,25 @@ public interface OrderMenuRepository extends JpaRepository<OrderMenu, UUID> {
     """)
     List<OrderMenu> findAllWithOptionsByTotalOrderId(
             @org.springframework.data.repository.query.Param("totalOrderId") UUID totalOrderId
+    );
+
+    // 취소된 주문을 제외한 orderMenuList를 fetch join으로 추출.
+    @Query("""
+      select distinct om
+      from OrderMenu om
+      join om.unitOrder uo
+      join uo.totalOrder to
+      left join fetch om.orderMenuOptionList omo
+      left join fetch omo.subOption so
+      left join fetch so.mainOption mo
+      left join fetch om.menu m
+      where to.id = :totalOrderId
+        and uo.status <> :cancelled
+      order by om.id
+    """)
+    List<OrderMenu> findAllActiveMenusWithOptionsByTotalOrderId(
+            @Param("totalOrderId") UUID totalOrderId,
+            @Param("cancelled") OrderStatus cancelled
     );
 
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/OrderStatusService.java
@@ -54,7 +54,7 @@ public class OrderStatusService {
 
     /**
      * 필수 로직 변환 작업
-     * 추후 redis 재고 도입으로 인한 리팩토링 필요함.
+     * TODO: 추후 redis 재고 도입으로 인한 리팩토링 필요함.
      */
     // 접수된 주문 상태변경(주문완료, 취소) 로직
     public UnitOrderStatusResDTO updateUnitOrderStatus(UUID unitOrderId, OrderStatusUpdateReqDTO reqDTO) {

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/controller/OrderTableStatusController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/controller/OrderTableStatusController.java
@@ -7,6 +7,7 @@ import com.beyond.jellyorder.domain.storetable.dto.zone.ZoneListResDTO;
 import com.beyond.jellyorder.domain.storetable.dto.orderTableStatus.OrderTableResDTO;
 import com.beyond.jellyorder.domain.storetable.service.OrderTableStatusService;
 import com.beyond.jellyorder.domain.storetable.service.ZoneService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -52,11 +53,11 @@ public class OrderTableStatusController {
     // 주문 테이블 주문 수정
     @PutMapping("/update")
     public ResponseEntity<?> updateOrderTable(
-            @RequestBody List<OrderTableUpdateReqDTO> reqDTOs
+            @RequestBody @Valid OrderTableUpdateReqDTO reqDTO
     ) {
-        orderTableStatusService.updateOrderTable(reqDTOs);
+        UUID updateUnitOrder = orderTableStatusService.updateOrderTable(reqDTO);
 
-        return ApiResponse.ok(null, "주문 수정 완료");
+        return ApiResponse.ok(updateUnitOrder, "주문 수정 완료");
     }
 
 

--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/OrderTableUpdateReqDTO.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/orderTableStatus/OrderTableUpdateReqDTO.java
@@ -1,5 +1,6 @@
 package com.beyond.jellyorder.domain.storetable.dto.orderTableStatus;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,6 @@ import java.util.UUID;
 @AllArgsConstructor
 public class OrderTableUpdateReqDTO {
     private UUID unitOrderId;
+    @NotEmpty(message = "수정되는 주문이 없습니다.")
     private List<MenuDetail> menuDetailList;
 }


### PR DESCRIPTION
### 📋 작업 개요
주문테이블 수정 API 리팩토링

<br/>


### 🔧 작업 상세
- 기존 List형식의 요청에서 단건 주문(UnitOrder)로 변경
- TotalOrder의 totalCount필드값을 최신화 하는 내부 메서드 정의
- OrderMenu리포지토리에 취소된 단건주문을 제외한 나머지 OrderMenu리스트를 fetchJoin하는 로직 추가 

<br/>


### 📌 이슈 번호
close #181 

<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.