### PR TITLE
[Feat] Redis로 주문번호 생성 로직 구현 (#193)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/redis/DefaultRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/redis/DefaultRedisConfig.java
@@ -20,7 +20,7 @@ public class DefaultRedisConfig {
         this.props = props;
     }
 
-    // 기본 Redis: 0번 / StoreAuthRedis: 1번 / StoreTableAuth: 2번 / Sse: 7번
+    // 기본 Redis: 0번 / StoreAuthRedis: 1번 / StoreTableAuth: 2번 / Sse: 7번 / OrderNumberRedis: 3번
     /* 총 0, 1, 2, 7 사용중! */
     @Bean(name = "defaultRedisConnectionFactory")
     @Primary // 충돌 방지용, 이 factory를 기본으로 사용

--- a/src/main/java/com/beyond/jellyorder/common/redis/OrderNumberRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/redis/OrderNumberRedisConfig.java
@@ -1,0 +1,46 @@
+package com.beyond.jellyorder.common.redis;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class OrderNumberRedisConfig {
+
+    private final RedisProperties props;
+
+    public OrderNumberRedisConfig(RedisProperties props) {
+        this.props = props;
+    }
+
+    // 채번 DB
+    @Bean(name = "orderNumber")
+    public RedisConnectionFactory orderNumberConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(props.getHost());
+        configuration.setPort(props.getPort());
+        configuration.setDatabase(4);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean(name = "orderNumberTemplate")
+    public RedisTemplate<String, String> orderNumberTemplate(
+            @Qualifier("orderNumber") RedisConnectionFactory redisConnectionFactory
+    ) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/CollectOrderNumberService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/CollectOrderNumberService.java
@@ -1,0 +1,41 @@
+package com.beyond.jellyorder.domain.order.service;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class CollectOrderNumberService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String KEY_PREFIX = "order:seq:";
+    private String key(UUID storeId) {
+        return KEY_PREFIX + storeId;
+    }
+
+    public CollectOrderNumberService(@Qualifier("orderNumberTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Integer collectNum(UUID storeId) {
+        Long seq = redisTemplate.opsForValue().increment(key(storeId));
+        if (seq == null) throw new IllegalStateException("주문번호 Redis값 증가 실패. ");
+        return seq.intValue();
+    }
+
+    public long currentNum(UUID storeId) {
+        String v = redisTemplate.opsForValue().get(key(storeId));
+        return (v == null) ? 0L : Long.parseLong(v);
+    }
+
+    /**
+     *  마감 시 해당 매장의 채번DB 초기화
+     *  key값을 삭제해도 opsForValue().increment를 하면 0에서 1로 증가 및 key값 설정해 줌.
+     */
+    public void resetOrderNum(UUID storeId) {
+        redisTemplate.delete(key(storeId));
+    }
+
+}

--- a/src/main/java/com/beyond/jellyorder/domain/order/service/UnitOrderService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/service/UnitOrderService.java
@@ -1,5 +1,7 @@
 package com.beyond.jellyorder.domain.order.service;
 
+import com.beyond.jellyorder.common.auth.StoreJwtClaimUtil;
+import com.beyond.jellyorder.common.auth.StoreTableJwtClaimUtil;
 import com.beyond.jellyorder.domain.menu.domain.Menu;
 import com.beyond.jellyorder.domain.menu.domain.MenuStatus;
 import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
@@ -41,6 +43,8 @@ public class UnitOrderService {
     private final MenuRepository menuRepository;
     private final OrderMenuRepository orderMenuRepository;
     private final SubOptionRepository subOptionRepository;
+    private final CollectOrderNumberService collectOrderNumberService;
+    private final StoreTableJwtClaimUtil storeTableJwtClaimUtil;
 
     public OrderStatusResDTO createUnit(UnitOrderCreateReqDto dto) {
         // 1. 테이블 조회
@@ -50,7 +54,7 @@ public class UnitOrderService {
         TotalOrder totalOrder = getOrCreateTotalOrder(storeTable);
 
         // 3. 단위주문 생성
-        UnitOrder unitOrder = createUnitOrder(totalOrder);
+        UnitOrder unitOrder = createUnitOrder(totalOrder, UUID.fromString(storeTableJwtClaimUtil.getStoreId()));
 
         // 4. 메뉴 처리 (재고 검증 + 주문/옵션 저장 + 합산)
         UnitOrderResult result = processMenus(dto.getMenuList(), unitOrder);
@@ -88,10 +92,12 @@ public class UnitOrderService {
     }
 
     // 3. 단위주문 생성
-    private UnitOrder createUnitOrder(TotalOrder totalOrder) {
+    private UnitOrder createUnitOrder(TotalOrder totalOrder, UUID storeId) {
+        Integer orderNumber = collectOrderNumberService.collectNum(storeId);
         UnitOrder unitOrder = UnitOrder.builder()
                 .totalOrder(totalOrder)
                 .status(OrderStatus.ACCEPT)
+                .orderNumber(orderNumber)
                 .totalCount(0)
                 .build();
         return unitOrderRepository.save(unitOrder);

--- a/src/main/java/com/beyond/jellyorder/domain/test/TestController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/test/TestController.java
@@ -2,18 +2,23 @@ package com.beyond.jellyorder.domain.test;
 
 import com.beyond.jellyorder.common.apiResponse.ApiResponse;
 import com.beyond.jellyorder.common.s3.S3Manager;
+import com.beyond.jellyorder.domain.order.service.CollectOrderNumberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/test")
 public class TestController {
 
     private final S3Manager s3Manager;
+    private final CollectOrderNumberService collectOrderNumberService;
 
-    public TestController(S3Manager s3Manager) {
+    public TestController(S3Manager s3Manager, CollectOrderNumberService collectOrderNumberService) {
         this.s3Manager = s3Manager;
+        this.collectOrderNumberService = collectOrderNumberService;
     }
 
     /**
@@ -21,11 +26,11 @@ public class TestController {
      *
      * @param file 업로드할 MultipartFile 형식의 이미지 파일
      * @return 업로드된 이미지의 S3 URL
-     *
+     * <p>
      * [prefix 설명]
      * - 두 번째 인자인 "test"는 S3 저장 경로 상의 디렉토리 prefix로 사용됩니다.
      * - 예: prefix가 "test"이고 파일명이 "image.png"인 경우,
-     *       S3에 저장되는 key는 "test/{UUID}-image.png" 형식이 됩니다.
+     * S3에 저장되는 key는 "test/{UUID}-image.png" 형식이 됩니다.
      * - 이를 통해 메뉴, 프로필, 배너 등 업로드 대상에 따라 구분된 디렉토리 구조를 유지할 수 있습니다.
      */
     @PostMapping("/s3upload")
@@ -71,5 +76,19 @@ public class TestController {
     public ResponseEntity<?> testJinho() {
         TestDTO testDTO = new TestDTO("hello", 23);
         return ApiResponse.ok(testDTO);
+    }
+
+    // 주문번호 채번 테스트
+    @GetMapping("/resetOrderNum/{storeId}")
+    public ResponseEntity<?> resetNumber(@PathVariable UUID storeId) {
+        collectOrderNumberService.resetOrderNum(storeId);
+        return ApiResponse.ok(null, "리셋 성공, redis DB에서 실제로 없어졌는 지 확인해주세요.");
+    }
+
+    // 주문번호 채번 테스트
+    @GetMapping("/currentNum/{storeId}")
+    public ResponseEntity<?> currentNum(@PathVariable UUID storeId) {
+        long num = collectOrderNumberService.currentNum(storeId);
+        return ApiResponse.ok(num);
     }
 }


### PR DESCRIPTION
### 📋 작업 개요
Redis로 주문번호 생성 로직 구현

<br/>


### 🔧 작업 상세
- redis의 4번 DB에 order:seq:storeId 키값으로 채번테이블 구현
- 주문 시 redisTemplate에서 채번하여 unitOrder 생성할 때 insert
- 마감 시 주문번호 초기화를 위해 키값을 삭제할 수 있는 resetOrderNum메서드 구현 

<br/>




### 📌 이슈 번호
close: #193 

<br/>


### ⚠️ 참고사항
- 마감 백엔드 로직 때 주문번호 초기화를 위한 메서드입니다.
<img width="1054" height="752" alt="스크린샷 2025-09-03 오후 11 18 24" src="https://github.com/user-attachments/assets/b030f4e6-5941-4ef7-b2da-aa088ff6eeea" />

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.