### PR TITLE
[Feat] 구역 삭제 시 EATING 테이블 검증 및 StoreTableDetail 상태 필드 추가 (#198)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/storetable/dto/storeTable/StoreTableDetail.java
+++ b/src/main/java/com/beyond/jellyorder/domain/storetable/dto/storeTable/StoreTableDetail.java
@@ -1,6 +1,7 @@
 package com.beyond.jellyorder.domain.storetable.dto.storeTable;
 
 import com.beyond.jellyorder.domain.storetable.entity.StoreTable;
+import com.beyond.jellyorder.domain.storetable.entity.TableStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,12 +14,14 @@ public class StoreTableDetail {
     private UUID storeTableId;
     private String storeTableName;
     private Integer seatCount;
+    private TableStatus tableStatus;
 
     public static StoreTableDetail from(StoreTable storeTable) {
         return StoreTableDetail.builder()
                 .storeTableId(storeTable.getId())
                 .storeTableName(storeTable.getName())
                 .seatCount(storeTable.getSeatCount())
+                .tableStatus(storeTable.getStatus())
                 .build();
     }
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
구역 삭제 시 테이블 상태 검증 및 DTO 확장

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- StoreTableDetail DTO에 tableStatus 필드 추가하여 테이블 상태를 응답에 포함
- StoreTable → StoreTableDetail 변환 시 상태 매핑 로직 반영
- ZoneService 구역 삭제 로직 개선
  - 구역 내 테이블 목록 조회 및 EATING 상태 여부 검사
  - 사용 중(EATING) 테이블 존재 시 예외 발생 처리
- 데이터 무결성 보장을 위한 검증 로직 강화

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #198 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- 기존 구역 삭제 로직에서 단순 삭제 대신 검증 절차가 추가되었으므로, 테스트 시 EATING 상태를 가진 테이블이 포함된 구역은 삭제되지 않음
- 프론트엔드에서 테이블 상태 표시(TableManagementPage)와 일관성 있게 동작

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.