### PR TITLE
[Fix] 요청사항, 메뉴 품절 처리 분기처리 및 요청사항 영속 저장 (#190)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/common/redis/SseRedisConfig.java
+++ b/src/main/java/com/beyond/jellyorder/common/redis/SseRedisConfig.java
@@ -2,7 +2,9 @@
 package com.beyond.jellyorder.common.redis;
 
 import com.beyond.jellyorder.domain.menu.sse.MenuStatusRedisSubscriber;
+import com.beyond.jellyorder.domain.menu.sse.MenuStatusToSseBridge;
 import com.beyond.jellyorder.domain.sseRequest.service.SseAlarmService;
+import com.beyond.jellyorder.domain.sseRequest.sse.RequestRedisSubscriber;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +16,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -43,7 +46,38 @@ public class SseRedisConfig {
         return container;
     }
 
+    @Bean(name = "requestListenerAdapter")
+    public MessageListenerAdapter requestListenerAdapter(RequestRedisSubscriber requestRedisSubscriber) {
+        return new MessageListenerAdapter(requestRedisSubscriber, "onMessage");
+    }
+
+    @Bean(name = "requestRedisMessageListenerContainer")
+    public RedisMessageListenerContainer requestRedisMessageListenerContainer(
+            @Qualifier("ssePubSub") RedisConnectionFactory redisConnectionFactory,
+            @Qualifier("requestListenerAdapter") MessageListenerAdapter listenerAdapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic("request-channel"));
+        return container;
+    }
+
     // ===== 2) tablet-menu-status:* → MenuStatusRedisSubscriber =====
+    @Bean(name = "menuStatusBridgeListenerAdapter")
+    public MessageListenerAdapter menuStatusBridgeListenerAdapter(MenuStatusToSseBridge bridge) {
+        return new MessageListenerAdapter(bridge, "onMessage");
+    }
+
+    @Bean(name = "menuStatusBridgeContainer")
+    public RedisMessageListenerContainer menuStatusBridgeContainer(
+            @Qualifier("ssePubSub") RedisConnectionFactory cf,
+            @Qualifier("menuStatusBridgeListenerAdapter") MessageListenerAdapter adapter) {
+        var c = new RedisMessageListenerContainer();
+        c.setConnectionFactory(cf);
+        c.addMessageListener(adapter, new PatternTopic("tablet-menu-status:*"));
+        return c;
+    }
+
     @Bean(name = "menuStatusListenerAdapter")
     public MessageListenerAdapter menuStatusListenerAdapter(MenuStatusRedisSubscriber subscriber) {
         // 바이트 그대로 넘겨서 subscriber가 직접 ObjectMapper로 파싱 (현재 구현 유지)
@@ -75,16 +109,17 @@ public class SseRedisConfig {
     public RedisTemplate<String, Object> sseRedisTemplate(
             @Qualifier("ssePubSub") RedisConnectionFactory cf
     ) {
-        // ⬅️ 채널(topic)은 String, 메시지 value도 "String(JSON)"로 보냅니다
+        // 채널(topic)은 String, 메시지 value도 "String(JSON)"
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(cf);
 
-        StringRedisSerializer stringSer = new StringRedisSerializer();
+        var keySer = new StringRedisSerializer();
+        var jsonSer = new GenericJackson2JsonRedisSerializer();
 
-        template.setKeySerializer(stringSer);
-        template.setValueSerializer(stringSer);
-        template.setHashKeySerializer(stringSer);
-        template.setHashValueSerializer(stringSer);
+        template.setKeySerializer(keySer);
+        template.setValueSerializer(jsonSer);
+        template.setHashKeySerializer(keySer);
+        template.setHashValueSerializer(jsonSer);
 
         template.setEnableDefaultSerializer(false);
         template.afterPropertiesSet();

--- a/src/main/java/com/beyond/jellyorder/domain/menu/sse/MenuStatusToSseBridge.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/sse/MenuStatusToSseBridge.java
@@ -1,0 +1,33 @@
+package com.beyond.jellyorder.domain.menu.sse;
+
+import com.beyond.jellyorder.domain.menu.dto.MenuStatusChangedEvent;
+import com.beyond.jellyorder.domain.sseRequest.sse.SseEmitters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MenuStatusToSseBridge implements MessageListener {
+
+    private final SseEmitters emitters;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            MenuStatusChangedEvent evt =
+                    objectMapper.readValue(message.getBody(), MenuStatusChangedEvent.class);
+
+            String storeId = evt.getStoreId().toString();
+            // 같은 SSE 파이프(SseEmitters)로 재송출
+            emitters.send(storeId, "menu-status", evt);
+        } catch (Exception e) {
+            log.warn("[BRIDGE] fail forwarding menu-status to SSE", e);
+        }
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/sseRequest/controller/RequestSseController.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sseRequest/controller/RequestSseController.java
@@ -10,16 +10,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+
 // 점주 SSE 구독용
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/sse/request")
 @PreAuthorize("hasAnyRole('STORE','STORE_TABLE')")
 public class RequestSseController { 
     private final SseEmitters emitters;
 
-    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@RequestParam String storeId) {
+    @GetMapping(value="/sse/request/subscribe", produces=MediaType.TEXT_EVENT_STREAM_VALUE)    public SseEmitter subscribe(@RequestParam String storeId) throws IOException {
         SseEmitter sseEmitter = new SseEmitter(Long.MAX_VALUE);
         emitters.add(storeId, sseEmitter); // 내부에서 connect 이벤트 전송됨
         return sseEmitter;

--- a/src/main/java/com/beyond/jellyorder/domain/sseRequest/sse/RequestRedisSubscriber.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sseRequest/sse/RequestRedisSubscriber.java
@@ -1,0 +1,29 @@
+package com.beyond.jellyorder.domain.sseRequest.sse;
+
+import com.beyond.jellyorder.domain.menu.dto.MenuStatusChangedEvent;
+import com.beyond.jellyorder.domain.sse.SseHub;
+import com.beyond.jellyorder.domain.sseRequest.dto.RequestCreateDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class RequestRedisSubscriber implements MessageListener {
+    private final SseEmitters emitters;
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            RequestCreateDto dto = om.readValue(message.getBody(), RequestCreateDto.class);
+            emitters.send(dto.getStoreId(), "request", dto);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/beyond/jellyorder/domain/sseRequest/sse/SseEmitters.java
+++ b/src/main/java/com/beyond/jellyorder/domain/sseRequest/sse/SseEmitters.java
@@ -18,35 +18,42 @@ public class SseEmitters {
     // 1 store당 다중 디바이스 연결 허용을 위한 List<SseEmitter>>
     private final Map<String, List<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
 
-    // SSE 연결 추가 및 연결 해제 시 리스트에서 자동 제거
-    public void add(String storeId, SseEmitter emitter) {
-        // storeId로 된 emitter 리스트가 없으면 새로 생성
-        emitterMap.computeIfAbsent(storeId, key -> new CopyOnWriteArrayList<>()).add(emitter);
+    public void add(String storeId, SseEmitter emitter) throws IOException {
+        var list = emitterMap.computeIfAbsent(storeId, k -> new CopyOnWriteArrayList<>());
+        list.add(emitter);
 
-        emitter.onCompletion(() -> emitterMap.remove(storeId));
-        emitter.onTimeout(() -> emitterMap.remove(storeId));
+        Runnable remove = () -> {
+            List<SseEmitter> l = emitterMap.get(storeId);
+            if (l != null) {
+                l.remove(emitter);
+                if (l.isEmpty()) emitterMap.remove(storeId);
+            }
+        };
+        emitter.onCompletion(remove);
+        emitter.onTimeout(remove);
 
-        try {
-            emitter.send(SseEmitter.event().name("connect").data("연결완료"));
-        } catch (IOException e) {
-            emitterMap.remove(storeId);
-        }
+        emitter.send(SseEmitter.event().name("connected").data("연결완료"));
     }
 
-    // 특정 점주에게 알림 전송
-    public void notifyStore(String storeId, RequestCreateDto dto) {
+    /** ★ 범용 전송: 어떤 이벤트 이름이든 보냄 */
+    public void send(String storeId, String eventName, Object payload) {
         List<SseEmitter> emitters = emitterMap.get(storeId);
-
         if (emitters == null || emitters.isEmpty()) return;
 
         for (SseEmitter emitter : new ArrayList<>(emitters)) {
             try {
-                emitter.send(SseEmitter.event().name("request").data(dto));
+                emitter.send(SseEmitter.event().name(eventName).data(payload));
             } catch (IOException e) {
                 emitter.completeWithError(e);
-                emitters.remove(emitter);  // 실패한 emitter 제거
+                emitters.remove(emitter);
             }
         }
+    }
+
+
+    // 특정 점주에게 알림 전송
+    public void notifyStore(String storeId, RequestCreateDto dto) {
+        send(storeId, "request", dto);
     }
 
     // 현재 연결된 점주 수 확인용


### PR DESCRIPTION
### 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
요청사항, 메뉴 품절 처리 분기처리 및 요청사항 영속 저장 
<br/>


### 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
 - 주문/요청/메뉴상태 Pub/Sub 분리
 - 주문/요청/메뉴상태 리스너 구성 추가
 - 템플릿 직렬화 변경
 - 메뉴 상태, 요청사항 sse 브릿지 추가하여 같은 SSE 파이프(SseEmitters)로 재송출
 - RequestSseController의 엔드포인트 한 번에 설정
 - 범용 이벤트 전송 설정
<br/>


### 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
#190 
<br/>


### ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [ ] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.