### PR TITLE
[Refactor, Feat] 메뉴·카테고리 도메인에 소프트 삭제 체계 도입 및 메뉴 삭제 안전 검증 강화(EATING 테이블 연동) (#206)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/domain/Category.java
@@ -4,6 +4,9 @@ import com.beyond.jellyorder.common.BaseIdAndTimeEntity;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+
+import java.time.LocalDateTime;
 
 /**
  * 카테고리(Category) 도메인 엔티티.
@@ -12,19 +15,19 @@ import lombok.*;
  *
  * 상위 BaseIdAndTimeEntity를 상속받아 ID, 생성일, 수정일을 공통 관리한다.
  */
-@Getter
 @Entity
-@Builder
-@ToString
+@Table(name = "category")
+@Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "category", uniqueConstraints = {
-        @UniqueConstraint(
-                name = "uk_category_storeId_name",
-                columnNames = {"store_id", "name"}
-        )
-})
+@Builder
+@SQLDelete(sql = """
+  update category
+     set deleted = true,
+         deleted_at = now()
+   where id = ?
+""")
 public class Category extends BaseIdAndTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "store_id", nullable = false)
@@ -36,4 +39,11 @@ public class Category extends BaseIdAndTimeEntity {
 
     @Column(length = 255, nullable = false)
     private String description;
+
+    @Builder.Default
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/category/repository/CategoryRepository.java
@@ -1,16 +1,59 @@
 package com.beyond.jellyorder.domain.category.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.beyond.jellyorder.domain.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface CategoryRepository extends JpaRepository<Category, UUID>, CategoryRepositoryCustom{
-    boolean existsByStoreIdAndName(UUID store_id, String name);
-    Optional<Category> findByStoreIdAndName(UUID store_id, String name);
-    List<Category> findAllByStoreId(UUID store_id);
-    Optional<Category> findByIdAndStoreId(UUID id, UUID store_id);
-    int deleteByStore_IdAndName(UUID storeId, String name);
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    /* ===== 조회 ===== */
+
+    boolean existsByStoreIdAndNameAndDeletedFalse(UUID storeId, String name);
+
+    List<Category> findAllByStoreIdAndDeletedFalse(UUID storeId);
+
+    Optional<Category> findByIdAndStoreIdAndDeletedFalse(UUID id, UUID storeId);
+
+    Optional<Category> findByStoreIdAndNameAndDeletedFalse(UUID storeId, String name);
+
+    // 🔹 삭제본 여러 개일 수 있으므로 “가장 최근 1건”만 가져오기
+    Optional<Category> findTopByStoreIdAndNameAndDeletedTrueOrderByDeletedAtDesc(UUID storeId, String name);
+
+    // (필요 시) 삭제본 전부 보고 싶으면 이거 사용
+    List<Category> findAllByStoreIdAndNameAndDeletedTrue(UUID storeId, String name);
+
+
+    /* ===== 소프트 삭제 / 복구 ===== */
+
+    // 소프트 삭제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+      update Category c
+         set c.deleted = true,
+             c.deletedAt = CURRENT_TIMESTAMP
+       where c.store.id = :storeId
+         and c.name = :name
+         and c.deleted = false
+    """)
+    int softDeleteByStoreIdAndName(@Param("storeId") UUID storeId,
+                                   @Param("name") String name);
+
+    // 🔹 단건 복구 (가장 최근 삭제본의 id로 복구하도록 서비스에서 호출)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+      update Category c
+         set c.deleted = false,
+             c.deletedAt = null,
+             c.description = :description
+       where c.id = :id
+         and c.deleted = true
+    """)
+    int restoreById(@Param("id") UUID id,
+                    @Param("description") String description);
 }

--- a/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/domain/Menu.java
@@ -5,6 +5,8 @@ import com.beyond.jellyorder.domain.category.domain.Category;
 import com.beyond.jellyorder.domain.option.mainOption.domain.MainOption;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import static com.beyond.jellyorder.domain.menu.domain.MenuStatus.*;
@@ -58,6 +60,13 @@ public class Menu extends BaseIdAndTimeEntity {
     @Builder.Default
     @Column(name = "stock_status", nullable = false)
     private MenuStatus stockStatus = ON_SALE;
+
+    @Builder.Default
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     // 재고 상태 변환 함수
     public void changeStockStatus(MenuStatus newStatus) {

--- a/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/menu/repository/MenuRepository.java
@@ -1,16 +1,40 @@
 package com.beyond.jellyorder.domain.menu.repository;
 
 import com.beyond.jellyorder.domain.menu.domain.Menu;
-import com.beyond.jellyorder.domain.menu.domain.MenuStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuRepository  extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
-    List<Menu> findAllByCategory_StoreId(UUID category_store_id);
-    boolean existsByCategory_StoreIdAndCategory_Name(UUID category_store_id, String category_name);
+public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
+
+    List<Menu> findAllByCategory_StoreIdAndDeletedFalseAndCategory_DeletedFalse(UUID storeId);
+
+    Optional<Menu> findByIdAndDeletedFalse(UUID id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    update Menu m
+       set m.deleted = true,
+           m.deletedAt = CURRENT_TIMESTAMP
+     where m.id = :id
+    """)
+    int softDeleteById(@Param("id") UUID id);
+
+    @Query("""
+        select (count(m) > 0)
+          from Menu m
+         where m.deleted = false
+           and m.category.deleted = false
+           and m.category.store.id = :storeId
+           and m.category.name = :categoryName
+    """)
+    boolean existsAliveMenuByStoreIdAndCategoryName(
+            @Param("storeId") UUID storeId,
+            @Param("categoryName") String categoryName
+    );
 }

--- a/src/main/java/com/beyond/jellyorder/domain/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/beyond/jellyorder/domain/order/repository/OrderMenuRepository.java
@@ -71,4 +71,14 @@ public interface OrderMenuRepository extends JpaRepository<OrderMenu, UUID> {
             @Param("cancelled") OrderStatus cancelled
     );
 
+    @Query("""
+        select (count(om) > 0)
+          from OrderMenu om
+          join om.unitOrder uo
+          join uo.totalOrder to2
+          join to2.storeTable st
+         where om.menu.id = :menuId
+           and st.status = com.beyond.jellyorder.domain.storetable.entity.TableStatus.EATING
+        """)
+    boolean existsInEatingTable(@Param("menuId") UUID menuId);
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
메뉴·카테고리 도메인에 소프트 삭제 체계 도입 및 메뉴 삭제 안전 검증 강화(EATING 테이블 연동)

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- OrderMenuRepository
  - existsInEatingTable(menuId) JPQL 추가: 특정 메뉴가 EATING 상태 테이블의 주문에 포함되어 있는지 여부 확인

- MenuService

  - 메뉴 삭제 시 매장 소속(storeId)·메뉴 존재 여부 검증 강화

  - existsInEatingTable 연동하여 진행 중 식사(EATING) 테이블에 포함된 메뉴 삭제 차단

  - 물리 삭제 대신 소프트 삭제로 전환 (menuRepository.softDeleteById)

- MenuRepository

  - softDeleteById(id) 추가(삭제 플래그/삭제 시각 갱신)

  - existsAliveMenuByStoreIdAndCategoryName(storeId, categoryName) 추가(유효 메뉴 존재 확인)

  - 조회 계열 메서드에 deleted=false 조건 반영

- Menu 엔티티

  - 소프트 삭제 필드 추가: deleted, deletedAt

  - stockStatus 기본값 ON_SALE 설정

- CategoryService

  - 카테고리 조회 시 deleted=false 조건 반영

  - 카테고리 삭제 로직을 softDeleteByStoreIdAndName 기반으로 변경

  - 삭제 전 해당 카테고리에 속한 메뉴 존재 여부 검사(존재 시 삭제 불가)

- CategoryRepository

  - softDeleteByStoreIdAndName(storeId, name) 추가

  - restoreById(id, description) 복구 메서드 추가

  - 조회 메서드 일괄 deleted=false 조건 반영

- Category 엔티티

  - 소프트 삭제 필드 추가: deleted, deletedAt

  - Hibernate @SQLDelete 제거 → 명시적 업데이트 방식으로 전환

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #206 

<br/>

## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- DB 스키마 변화: menu, category 테이블에 deleted(boolean), deleted_at(datetime) 컬럼 필요
- 동작 변경점: 

  - 메뉴 삭제는 소프트 삭제로 처리됩니다(관련 조회는 deleted=false 기준).

  - EATING 상태 테이블 주문에 포함된 메뉴는 삭제가 차단됩니다.

  - 카테고리에 유효 메뉴가 남아있으면 카테고리 삭제가 차단됩니다.

- 배포 후 기존 데이터에 대해 deleted=false 기본값 보장 및 인덱스(필요 시 deleted, store_id, name 조합) 점검 권장

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.