### PR TITLE
[Feat] IngredientService 상태 연동 및 메뉴 재고/이벤트 처리 추가 (#208)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
@@ -8,12 +8,14 @@ import com.beyond.jellyorder.domain.ingredient.dto.*;
 import com.beyond.jellyorder.domain.ingredient.repository.IngredientRepository;
 import com.beyond.jellyorder.domain.menu.domain.Menu;
 import com.beyond.jellyorder.domain.menu.domain.MenuStatus;
+import com.beyond.jellyorder.domain.menu.dto.MenuStatusChangedEvent;
 import com.beyond.jellyorder.domain.menu.repository.MenuIngredientRepository;
 import com.beyond.jellyorder.domain.menu.repository.MenuRepository;
 import com.beyond.jellyorder.domain.store.entity.Store;
 import com.beyond.jellyorder.domain.store.repository.StoreRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +24,11 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * 식자재(Ingredient) 관련 비즈니스 로직을 담당하는 서비스 클래스.
- * - 식자재 생성
- * - 중복 이름 검사
- * - 매장별 식자재 관리 등
+ * 식자재(Ingredient) 서비스
+ * 정책:
+ * - INSUFFICIENT(부족): 경고 상태로만 사용. 메뉴 상태 변경/이벤트 발행 없음.
+ * - EXHAUSTED(소진) 진입: 연관 메뉴(수동 품절 제외)를 OUT_OF_STOCK 전환 + SSE 발행.
+ * - EXHAUSTED 해제(SUFFICIENT/INSUFFICIENT로 전환): 다른 소진 재료가 없고 완판 아님, 수동 품절 아님이면 ON_SALE 복원 + SSE 발행.
  */
 @Service
 @Transactional
@@ -37,57 +40,46 @@ public class IngredientService {
     private final MenuRepository menuRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final StoreJwtClaimUtil storeJwtClaimUtil;
+    private final ApplicationEventPublisher eventPublisher;
 
-    /**
-     * 새로운 식자재를 생성한다.
-     * - 동일 매장(storeId) 내에서 이름(name)이 중복되면 예외를 발생시킨다.
-     * - 생성된 식자재를 저장 후 응답 DTO로 변환하여 반환한다.
-     *
-     * @param reqDto 클라이언트로부터 전달받은 식자재 생성 요청 DTO
-     * @return 생성된 식자재 정보를 담은 응답 DTO
-     * @throws DuplicateResourceException 동일 매장 내에 이름이 중복되는 경우
-     */
+    /* 생성 */
     public IngredientCreateResDto create(IngredientCreateReqDto reqDto) {
         final String storeId = storeJwtClaimUtil.getStoreId();
-        Store store = storeRepository.findById(UUID.fromString(storeId)).orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeId));
+        Store store = storeRepository.findById(UUID.fromString(storeId))
+                .orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeId));
 
         if (ingredientRepository.existsByStoreIdAndName(UUID.fromString(storeId), reqDto.getName())) {
             throw new DuplicateResourceException("이미 존재하는 식자재입니다: " + reqDto.getName());
         }
 
         try {
-            // 식자재 엔티티 생성
             Ingredient ingredient = Ingredient.builder()
                     .store(store)
                     .name(reqDto.getName())
                     .status(reqDto.getStatus())
                     .build();
 
-            // DB에 저장
             Ingredient saved = ingredientRepository.save(ingredient);
 
-            // 응답 DTO 반환
             return IngredientCreateResDto.builder()
                     .id(saved.getId())
                     .name(saved.getName())
                     .status(saved.getStatus())
                     .build();
-
         } catch (DataIntegrityViolationException e) {
-            // 동시성 문제로 인한 DB 중복 제약 위반 시 예외 변환
             throw new DuplicateResourceException("이미 존재하는 식자재입니다: " + reqDto.getName());
         }
     }
 
+    /* 조회 */
     @Transactional(readOnly = true)
     public IngredientListResDto getIngredientsByStoreId() {
         final String storeId = storeJwtClaimUtil.getStoreId();
-        storeRepository.findById(UUID.fromString(storeId)).orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeId));
+        storeRepository.findById(UUID.fromString(storeId))
+                .orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeId));
 
-        // 2) 원재료 조회
         List<Ingredient> ingredients = ingredientRepository.findAllByStoreId(UUID.fromString(storeId));
 
-        // 3) DTO 변환 (재료가 없으면 빈 리스트)
         List<IngredientResDto> dtos = ingredients.stream()
                 .map(i -> IngredientResDto.builder()
                         .id(i.getId())
@@ -96,67 +88,66 @@ public class IngredientService {
                         .build())
                 .toList();
 
-        // 4) 결과 반환
         return IngredientListResDto.builder()
                 .ingredients(dtos)
                 .build();
     }
 
+    /* 삭제 */
     @Transactional
     public IngredientDeleteResDto delete(String ingredientId) {
         final String storeId = storeJwtClaimUtil.getStoreId();
         storeRepository.findById(UUID.fromString(storeId))
                 .orElseThrow(() -> new EntityNotFoundException("유효하지 않은 storeId: " + storeId));
 
-        // 1) 대상 조회
         Ingredient ingredient = ingredientRepository.findById(UUID.fromString(ingredientId))
                 .orElseThrow(() -> new EntityNotFoundException("식자재를 찾을 수 없습니다. id=" + ingredientId));
 
-        // 2) 소속(storeId) 검증
         if (!ingredient.getStore().getId().equals(UUID.fromString(storeId))) {
             throw new EntityNotFoundException("요청한 매장에 속하지 않는 식자재입니다. id=" + ingredientId + ", storeId=" + storeId);
         }
 
-        // ✅ (A) 영향받는 메뉴 ID들을 미리 확보
+        // (A) 영향받는 메뉴 ID 확보
         var briefs = ingredientRepository.findAffectedMenus(ingredient.getId());
         List<UUID> affectedMenuIds = briefs.stream()
                 .map(b -> UUID.fromString(b.getId()))
                 .toList();
 
-        // 3) 삭제
+        // 실제 삭제
         ingredientRepository.delete(ingredient);
 
-        // ✅ (B) 상태 복원 로직
+        // (B) 상태 복원 로직: 더 이상 소진 재료가 없으면 OUT_OF_STOCK → ON_SALE
         if (!affectedMenuIds.isEmpty()) {
             List<Menu> menus = menuRepository.findAllById(affectedMenuIds);
             int changed = 0;
+            List<Menu> changedMenus = new java.util.ArrayList<>();
 
             for (Menu m : menus) {
-                // 수동 품절은 건드리지 않음
                 if (m.getStockStatus() == MenuStatus.SOLD_OUT_MANUAL) continue;
 
-                // 현재 OUT_OF_STOCK 이고, 판매제한으로 인한 소진 상태가 아니어야 함
                 boolean limitedSoldOut = (m.getSalesLimit() != null)
                         && !m.getSalesLimit().equals(-1)
                         && m.getSalesToday() != null
                         && m.getSalesToday().equals(m.getSalesLimit());
 
                 if (m.getStockStatus() == MenuStatus.OUT_OF_STOCK && !limitedSoldOut) {
-                    // 남아있는 연관 식자재 중 EXHAUSTED 가 하나라도 있으면 그대로 유지
                     long exhaustedCnt = menuIngredientRepository.countExhaustedByMenuId(m.getId());
                     if (exhaustedCnt == 0) {
                         m.changeStockStatus(MenuStatus.ON_SALE);
                         changed++;
+                        changedMenus.add(m);
                     }
                 }
             }
 
             if (changed > 0) {
                 menuRepository.saveAll(menus);
+                for (Menu cm : changedMenus) {
+                    publishMenuStatusIfPossible(cm);
+                }
             }
         }
 
-        // 4) 응답 조립
         var affected = briefs.stream()
                 .map(b -> IngredientDeleteResDto.AffectedMenuDto.builder()
                         .id(UUID.fromString(b.getId()))
@@ -171,6 +162,7 @@ public class IngredientService {
                 .build();
     }
 
+    /* 수정 */
     public IngredientModifyResDto modify(IngredientModifyReqDto req) {
         final String storeIdStr = storeJwtClaimUtil.getStoreId();
         final UUID storeId = UUID.fromString(storeIdStr);
@@ -187,7 +179,6 @@ public class IngredientService {
                 .orElseThrow(() ->
                         new EntityNotFoundException("식자재를 찾을 수 없습니다. id=" + req.getIngredientId() + ", storeId=" + storeIdStr));
 
-        // 기존 상태 백업
         final IngredientStatus prevStatus = ingredient.getStatus();
 
         // 이름 수정
@@ -211,26 +202,73 @@ public class IngredientService {
 
         Ingredient saved = ingredientRepository.save(ingredient);
 
-        // ✅ EXHAUSTED 로 변경된 경우: 이 재료를 쓰는 메뉴(동일 매장, 수동품절 제외)를 OUT_OF_STOCK 로 전환
+        /* ───────────────────────── 정책 반영 구간 ─────────────────────────
+         * INSUFFICIENT은 경고만: 상태 변경/이벤트 발행 없음
+         * EXHAUSTED 진입: OUT_OF_STOCK 전환 + 이벤트
+         * EXHAUSTED 해제(SUFFICIENT/INSUFFICIENT): 조건 충족 시 ON_SALE 복원 + 이벤트
+         * ──────────────────────────────────────────────────────────────── */
+
+        // (1) 보유/부족 → 소진(EXHAUSTED) 전환
         if (req.getStatus() == IngredientStatus.EXHAUSTED && prevStatus != IngredientStatus.EXHAUSTED) {
-            // 1) 조인테이블에서 메뉴 ID만 조회
             List<UUID> menuIds = menuIngredientRepository.findMenuIdsByIngredient(saved);
             if (!menuIds.isEmpty()) {
-                // 2) 해당 메뉴들 로드
                 List<Menu> menus = menuRepository.findAllById(menuIds);
 
                 int changed = 0;
+                List<Menu> changedMenus = new java.util.ArrayList<>();
+
                 for (Menu m : menus) {
-                    // SOLD_OUT_MANUAL 이 아니면 OUT_OF_STOCK으로
                     if (m.getStockStatus() != MenuStatus.SOLD_OUT_MANUAL
                             && m.getStockStatus() != MenuStatus.OUT_OF_STOCK) {
                         m.changeStockStatus(MenuStatus.OUT_OF_STOCK);
                         changed++;
+                        changedMenus.add(m);
                     }
                 }
 
                 if (changed > 0) {
                     menuRepository.saveAll(menus);
+                    for (Menu cm : changedMenus) {
+                        publishMenuStatusIfPossible(cm);
+                    }
+                }
+            }
+        }
+
+        // (2) 소진(EXHAUSTED) → 보유/부족(SUFFICIENT or INSUFFICIENT) 전환
+        if (prevStatus == IngredientStatus.EXHAUSTED && req.getStatus() != IngredientStatus.EXHAUSTED) {
+            List<UUID> menuIds = menuIngredientRepository.findMenuIdsByIngredient(saved);
+            if (!menuIds.isEmpty()) {
+                List<Menu> menus = menuRepository.findAllById(menuIds);
+                List<Menu> changedMenus = new java.util.ArrayList<>();
+
+                for (Menu m : menus) {
+                    // 수동 품절은 자동 복원 금지
+                    if (m.getStockStatus() == MenuStatus.SOLD_OUT_MANUAL) continue;
+
+                    // 현재 OUT_OF_STOCK인 경우만 복원 후보
+                    if (m.getStockStatus() != MenuStatus.OUT_OF_STOCK) continue;
+
+                    // 판매 한도 완판 상태면 복원 금지
+                    boolean limitedSoldOut = (m.getSalesLimit() != null)
+                            && !m.getSalesLimit().equals(-1)
+                            && m.getSalesToday() != null
+                            && m.getSalesToday().equals(m.getSalesLimit());
+                    if (limitedSoldOut) continue;
+
+                    // 남아있는 다른 EXHAUSTED 재료가 없어야 복원
+                    long exhaustedCnt = menuIngredientRepository.countExhaustedByMenuId(m.getId());
+                    if (exhaustedCnt == 0) {
+                        m.changeStockStatus(MenuStatus.ON_SALE);
+                        changedMenus.add(m);
+                    }
+                }
+
+                if (!changedMenus.isEmpty()) {
+                    menuRepository.saveAll(menus);
+                    for (Menu cm : changedMenus) {
+                        publishMenuStatusIfPossible(cm);
+                    }
                 }
             }
         }
@@ -242,5 +280,18 @@ public class IngredientService {
                 .createdAt(saved.getCreatedAt())
                 .updatedAt(saved.getUpdatedAt())
                 .build();
+    }
+
+    /* SSE 이벤트 퍼블리시 헬퍼 */
+    private void publishMenuStatusIfPossible(Menu m) {
+        if (m == null || m.getCategory() == null || m.getCategory().getStore() == null) return;
+        UUID storeId = m.getCategory().getStore().getId();
+        eventPublisher.publishEvent(
+                MenuStatusChangedEvent.builder()
+                        .storeId(storeId)
+                        .menuId(m.getId())
+                        .status(m.getStockStatus())
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
식자재 서비스 로직 개선 및 메뉴 재고 상태 자동 반영

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- 식자재 생성·조회·수정·삭제 로직에 매장 소속/중복/유효성 검증 및 예외 처리 강화

- EXHAUSTED 진입 시 연관 메뉴를 OUT_OF_STOCK으로 자동 전환 (수동 품절·완판 제외)

- EXHAUSTED 해제 시 조건 충족 시 ON_SALE 복원 (다른 소진 재료 없음, 판매한도 미달, 수동 품절 아님)

- 메뉴 상태 변경 시 MenuStatusChangedEvent 발행하여 실시간 반영

- 식자재 삭제 시 영향받는 메뉴 재고 상태 일괄 재계산 및 저장 처리

<br/>


## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #208 

<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  
- INSUFFICIENT(부족) 상태는 경고 전용으로, 메뉴 상태 변경이나 이벤트 발행을 하지 않음
- 메뉴 재고 계산 로직과 이벤트 발행 로직은 중복 호출 방지를 위해 분리된 헬퍼 메서드 사용

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.