### PR TITLE
[Feat] 식자재 응답 DTO에 updatedAt 필드를 추가하고, 서비스 계층에서 해당 필드를 매핑하여 반환하도록 개선 (#212)

### DIFF
--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientResDto.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/dto/IngredientResDto.java
@@ -3,6 +3,7 @@ package com.beyond.jellyorder.domain.ingredient.dto;
 import com.beyond.jellyorder.domain.ingredient.domain.IngredientStatus;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -13,4 +14,5 @@ public class IngredientResDto {
     private UUID id;
     private String name;
     private IngredientStatus status;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/beyond/jellyorder/domain/ingredient/service/IngredientService.java
@@ -85,6 +85,7 @@ public class IngredientService {
                         .id(i.getId())
                         .name(i.getName())
                         .status(i.getStatus())
+                        .updatedAt(i.getUpdatedAt())
                         .build())
                 .toList();
 


### PR DESCRIPTION
## 📋 작업 개요
<!-- 간단한 작업 요약을 한 줄로 작성해주세요 (예: 테이블 등록 API 개발) -->  
식자재 응답 DTO에 updatedAt 필드를 추가하고, 서비스 계층에서 해당 필드를 매핑하여 반환하도록 개선

<br/>


## 🔧 작업 상세
<!-- 주요 구현 내용, 로직, 조건 등을 리스트 형식으로 상세히 작성해주세요 -->  
- IngredientResDto에 updatedAt 필드 추가 및 LocalDateTime import 반영
- IngredientService에서 DTO 매핑 시 i.getUpdatedAt() 값 포함하여 응답 확장
- 클라이언트가 식자재의 최종 수정 시각을 확인할 수 있도록 데이터 제공

<br/>

## 📌 이슈 번호
<!-- 관련된 이슈 번호를 닫고 싶다면 `close #이슈번호` 형식으로 작성해주세요 -->  
close #212 

<br/>


## ⚠️ 참고사항
<!-- 코드 외 참고해야 할 사항이 있다면 자유롭게 작성해주세요 -->  

<br/>


## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  <!-- 예: feat: 테이블 등록 기능 구현 -->
- [x] PR 전 develop 브랜치로부터 Pull 후 충돌 여부를 확인/처리했습니다.